### PR TITLE
Require 'time' to get at #iso8601

### DIFF
--- a/lib/vedeu/api/log.rb
+++ b/lib/vedeu/api/log.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'time'
 
 module Vedeu
   module API


### PR DESCRIPTION
I think that a `time` require is usually needed to use this method.

Here's the exeption from playa:

```
undefined method `iso8601' for 2014-08-19 16:22:37 UTC:Time
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/api/log.rb:9:in `block (2 levels) in logger'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/2.1.0/logger.rb:491:in `call'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/2.1.0/logger.rb:491:in `format_message'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/2.1.0/logger.rb:379:in `add'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/2.1.0/logger.rb:400:in `debug'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/api/api.rb:33:in `log'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/api/api.rb:9:in `block (2 levels) in events'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/api/events.rb:33:in `call'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/api/events.rb:33:in `block in trigger'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/api/events.rb:33:in `each'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/api/events.rb:33:in `trigger'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/api/api.rb:37:in `trigger'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/api/api.rb:28:in `keypress'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/api/api.rb:14:in `block (2 levels) in events'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/api/events.rb:33:in `call'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/api/events.rb:33:in `block in trigger'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/api/events.rb:33:in `each'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/api/events.rb:33:in `trigger'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/api/api.rb:37:in `trigger'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/support/input.rb:10:in `capture'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/support/input.rb:4:in `capture'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/application.rb:38:in `main_sequence'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/application.rb:19:in `block (2 levels) in start'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/application.rb:29:in `block in runner'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/application.rb:46:in `block in interactive'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/application.rb:46:in `loop'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/application.rb:46:in `interactive'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/application.rb:29:in `runner'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/application.rb:19:in `block in start'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/support/terminal.rb:10:in `block (2 levels) in open'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/support/terminal.rb:45:in `initialize_screen'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/support/terminal.rb:10:in `block in open'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/support/terminal.rb:10:in `raw'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/support/terminal.rb:10:in `open'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/application.rb:14:in `start'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/application.rb:6:in `start'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/vedeu-0.1.14/lib/vedeu/launcher.rb:18:in `execute!'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/playa-0.0.12/lib/playa.rb:57:in `start'
/Users/brandur/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/playa-0.0.12/bin/playa:15:in `<top (required)>'
/Users/brandur/.rbenv/versions/2.1.2/bin/playa:23:in `load'
/Users/brandur/.rbenv/versions/2.1.2/bin/playa:23:in `<main>'
```
