### PR TITLE
Skip invisible interfaces when switching focus

### DIFF
--- a/lib/vedeu/models/focus.rb
+++ b/lib/vedeu/models/focus.rb
@@ -96,7 +96,25 @@ module Vedeu
       update
     end
     alias_method :next,       :next_item
-    alias_method :focus_next, :next_item
+
+    # Put the next visible interface relative to the current interfaces in
+    # focus.
+    #
+    # @return [String]
+    def next_visible_item
+      unless visible_items?
+        update
+        return
+      end
+
+      loop do
+        storage.rotate!
+        break if InterfacesRepository.interfaces.find(current).visible?
+      end
+
+      update
+    end
+    alias_method :focus_next, :next_visible_item
 
     # Put the previous interface relative to the current interface in focus.
     #
@@ -111,7 +129,25 @@ module Vedeu
     end
     alias_method :prev,           :prev_item
     alias_method :previous,       :prev_item
-    alias_method :focus_previous, :prev_item
+
+    # Put the previous visible interface relative to the current interfaces in
+    # focus.
+    #
+    # @return [String]
+    def prev_visible_item
+      unless visible_items?
+        update
+        return
+      end
+
+      loop do
+        storage.rotate!(-1)
+        break if InterfacesRepository.interfaces.find(current).visible?
+      end
+
+      update
+    end
+    alias_method :focus_previous, :prev_visible_item
 
     # Refresh the interface in focus.
     #
@@ -174,6 +210,12 @@ module Vedeu
     # @return [Array]
     def in_memory
       []
+    end
+
+    def visible_items?
+      storage.any? do |name|
+        InterfacesRepository.interfaces.find(name).visible?
+      end
     end
 
   end # Focus

--- a/test/lib/vedeu/models/focus_test.rb
+++ b/test/lib/vedeu/models/focus_test.rb
@@ -163,6 +163,18 @@ module Vedeu
       end
     end
 
+    describe '#next_visible_item' do
+      it 'the next visible interface is focussed when the method is called' do
+        Vedeu.interface('lead') { visible false }
+        Vedeu.interface('bismuth') { visible false }
+        Focus.add('thallium')
+        Focus.add('lead')
+        Focus.add('bismuth')
+
+        Focus.next_visible_item.must_equal('thallium')
+      end
+    end
+
     describe '#prev_item' do
       it 'the previous interface is focussed when the method is called' do
         Focus.add('thallium')
@@ -175,6 +187,16 @@ module Vedeu
         before { Focus.reset }
 
         it { Focus.prev_item.must_equal(false) }
+      end
+    end
+
+    describe '#prev_visible_item' do
+      it 'the previous visible interface is focussed when the method is called' do
+        Vedeu.interface('bismuth') { visible false }
+        Focus.add('thallium')
+        Focus.add('lead')
+        Focus.add('bismuth')
+        Focus.prev_visible_item.must_equal('lead')
       end
     end
 


### PR DESCRIPTION
Things I'm not sure about in this PR:

- Is there an easier way to get the interface?
- What is the interface order for focus based on? In the test for `focus_next` I would expect the next item to be thallium (for the 'pointer' to be on bismuth as the last added and for it to wrap around to get the next item).
- Related to previous question, in my Minder code tabbing goes "backward" from the way that I would expect (bottom to top). This is surprising because I put my interfaces in in the order I want them to be displayed from top to bottom https://github.com/tristil/minder/blob/master/lib/minder/application.rb#L54

```
This commit changes the alias for #focus_next from #next_item to a new
method #next_visible_item that skips over hidden interfaces. This seems
like a more intuitive behavior than allowing focus to shift to an
interface that is not visible.
```