### PR TITLE
Allow for customizable base path

### DIFF
--- a/lib/vedeu/application/application_view.rb
+++ b/lib/vedeu/application/application_view.rb
@@ -40,7 +40,8 @@ module Vedeu
     # @param value [String]
     # @return [String]
     def template(value)
-      @template = File.expand_path("./app/views/templates/#{value}.erb")
+      @template = Vedeu::Configuration.base_path +
+        "/app/views/templates/#{value}.erb"
     end
 
   end # ApplicationView

--- a/lib/vedeu/bootstrap.rb
+++ b/lib/vedeu/bootstrap.rb
@@ -27,8 +27,13 @@ module Vedeu
     def start
       Vedeu.configure { log('/tmp/vedeu_bootstrap.log') }
 
+      # config/configuration.rb is already loaded so don't load it twice
+      Dir[File.join(Vedeu::Configuration.base_path, 'config/**/*')].each do |f|
+        next if f =~ %r{config/configuration\.rb}
+        load f
+      end
+
       [
-        'config/**/*',
         'app/controllers/**/*',
         'app/helpers/**/*',
         'app/views/**/*',

--- a/lib/vedeu/bootstrap.rb
+++ b/lib/vedeu/bootstrap.rb
@@ -28,12 +28,12 @@ module Vedeu
       Vedeu.configure { log('/tmp/vedeu_bootstrap.log') }
 
       [
-        './config/**/*',
-        './app/controllers/**/*',
-        './app/helpers/**/*',
-        './app/views/**/*',
-        './app/models/keymaps/**/*',
-      ].each { |path| load(path) }
+        'config/**/*',
+        'app/controllers/**/*',
+        'app/helpers/**/*',
+        'app/views/**/*',
+        'app/models/keymaps/**/*',
+      ].each { |path| load(File.join(Vedeu::Configuration.base_path, path)) }
 
       entry_point
 

--- a/lib/vedeu/cli/generator/templates/application/application.erb
+++ b/lib/vedeu/cli/generator/templates/application/application.erb
@@ -1,3 +1,4 @@
+require_relative 'config/configuration'
 require_relative 'app/controllers/some_controller'
 
 module <%= object.name_as_class %>

--- a/lib/vedeu/configuration/api.rb
+++ b/lib/vedeu/configuration/api.rb
@@ -277,6 +277,16 @@ module Vedeu
       end
       alias_method :renderers, :renderer
 
+      # Override the base path for the application (for locating templates and
+      # other resources). By default the base path is just cwd but this will
+      # not work for many applications.
+      #
+      # @param value [String]
+      # @return [String]
+      def base_path(path = nil)
+        options[:base_path] = path
+      end
+
       # Sets the value of STDIN.
       #
       # @example

--- a/lib/vedeu/configuration/configuration.rb
+++ b/lib/vedeu/configuration/configuration.rb
@@ -34,6 +34,13 @@ module Vedeu
 
     class << self
 
+      # Returns the base_path value
+      #
+      # @return [String]
+      def base_path
+        instance.options[:base_path]
+      end
+
       # Configure Vedeu with sensible defaults. If the client application sets
       # options, override the defaults with those, and if command-line arguments
       # are provided at application invocation, override any options with the
@@ -241,6 +248,7 @@ module Vedeu
     # @return [Hash]
     def defaults
       {
+        base_path:     set_base_path,
         colour_mode:   detect_colour_mode,
         debug:         false,
         drb:           false,
@@ -270,6 +278,10 @@ module Vedeu
       when /-color$/, 'rxvt'     then 16
       else 256
       end
+    end
+
+    def set_base_path
+      File.expand_path('.')
     end
 
   end # Configuration

--- a/test/lib/vedeu/configuration/api_test.rb
+++ b/test/lib/vedeu/configuration/api_test.rb
@@ -12,6 +12,13 @@ module Vedeu
       before { Configuration.reset! }
       after  { test_configuration }
 
+      describe '#base_path' do
+        it 'sets the option to the desired value' do
+          configuration = Vedeu.configure { base_path 'somewhere' }
+          configuration.base_path.must_equal('somewhere')
+        end
+      end
+
       describe '.configure' do
         it 'returns the configuration singleton' do
           Vedeu.configure do

--- a/test/lib/vedeu/configuration/configuration_test.rb
+++ b/test/lib/vedeu/configuration/configuration_test.rb
@@ -9,6 +9,14 @@ module Vedeu
     before { Configuration.reset! }
     after  { test_configuration }
 
+    describe '#base_path' do
+      it { described.must_respond_to(:base_path) }
+
+      it 'returns the value of the base_path option' do
+        Configuration.base_path.must_equal(Dir.pwd)
+      end
+    end
+
     describe '#debug?' do
       it { described.must_respond_to(:debug) }
 


### PR DESCRIPTION
The idea is that my application is a global executable that needs to be run from anywhere so there can't be any implicit file references to the cwd. Also FWIW I have the Vedeu project skeleton living inside a folder in my application so the Vedeu root reference point at `lib/minder/cli/application.rb` is different from the root of the overall project.

```
ApplicationView#template and the loading code in Vedeu::Bootstrap
implicitly depend on files being located relative to cwd. This commit
adds a base_path configuration variable which *defaults* to cwd
(`File.expand_path('.')`) and which can be set in client code.

This probably isn't a good ultimate default because this won't work for
most common application scenarios. I punted on implementing what seems
like the most reasonable default, automatically setting the base path
relative to the location of the 'client' code. This is actually harder
that it might seem at first. This is how Rails sets its root config
value:

https://github.com/rails/rails/blob/3e36db4406beea32772b1db1e9a16cc1e8aea14c/railties/lib/rails/application.rb#L364

The approach used there seems a little intrusive so I've deferred the
decision for later.
```