### PR TITLE
Introduce EventAliases.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -29,8 +29,10 @@ Note: Nesting indicates where an API method is allowed/supposed to be used.
 ### Events
 
 - Vedeu.bind
+- Vedeu.bind_alias
 - Vedeu.trigger
 - Vedeu.unbind
+- Vedeu.unbind_alias
 
 ### Geometry
 

--- a/lib/vedeu/all.rb
+++ b/lib/vedeu/all.rb
@@ -79,6 +79,7 @@ require 'vedeu/output/renderers/terminal'
 require 'vedeu/output/renderers/text'
 require 'vedeu/output/renderers'
 
+require 'vedeu/events/event_aliases'
 require 'vedeu/events/trigger'
 require 'vedeu/events/events'
 require 'vedeu/events/event'

--- a/lib/vedeu/api.rb
+++ b/lib/vedeu/api.rb
@@ -101,9 +101,9 @@ module Vedeu
     def_delegators Vedeu::DSL::View, :interface, :renders, :render, :views
 
     # @example
-    #   Vedeu.bind
-    #   Vedeu.bound?
-    #   Vedeu.unbind
+    #   Vedeu.bind(name) { }
+    #   Vedeu.bound?(name)
+    #   Vedeu.unbind(name)
     #
     # @!method bind
     #   @see Vedeu::Event.bind
@@ -112,6 +112,16 @@ module Vedeu
     # @!method unbind
     #   @see Vedeu::Event.unbind
     def_delegators Vedeu::Event, :bind, :bound?, :unbind
+
+    # @example
+    #   Vedeu.bind_alias(alias_name, event_name)
+    #   Vedeu.unbind_alias(alias_name)
+    #
+    # @!method bind_alias
+    #   @see Vedeu::EventAliases.bind_alias
+    # @!method unbind_alias
+    #   @see Vedeu::EventAliases.unbind_alias
+    def_delegators Vedeu::EventAliases, :bind_alias, :unbind_alias
 
     # @example
     #   Vedeu.focus

--- a/lib/vedeu/bindings.rb
+++ b/lib/vedeu/bindings.rb
@@ -15,6 +15,8 @@ module Vedeu
     #
     # @return [TrueClass]
     def setup!
+      Vedeu::Events.reset!
+
       Vedeu::Bindings::Application.setup!
       Vedeu::Bindings::Visibility.setup!
       Vedeu::Bindings::Movement.setup!

--- a/lib/vedeu/bindings/movement.rb
+++ b/lib/vedeu/bindings/movement.rb
@@ -67,9 +67,8 @@ module Vedeu
         Vedeu.bind(:_cursor_origin_) do |name|
           Vedeu::Move.by_name(Vedeu::Cursor, :origin, name)
         end
-        Vedeu.bind(:_cursor_reset_) do |name|
-          Vedeu.trigger(:_cursor_origin_, name)
-        end
+
+        Vedeu.bind_alias(:_cursor_reset_, :_cursor_origin_)
       end
 
       # When triggered will return the current position of the cursor.
@@ -130,6 +129,7 @@ module Vedeu
       #
       # @example
       #   Vedeu.trigger(:_geometry_down_, name)
+      #   Vedeu.trigger(:_view_down_, name)
       #
       # @return [TrueClass]
       # @see Vedeu::Move
@@ -137,12 +137,15 @@ module Vedeu
         Vedeu.bind(:_geometry_down_) do |name|
           Vedeu::Move.by_name(Vedeu::Geometry, :down, name)
         end
+
+        Vedeu.bind_alias(:_view_down_, :_geometry_down_)
       end
 
       # Move the geometry left by one character.
       #
       # @example
       #   Vedeu.trigger(:_geometry_left_, name)
+      #   Vedeu.trigger(:_view_left_, name)
       #
       # @return [TrueClass]
       # @see Vedeu::Move
@@ -150,12 +153,15 @@ module Vedeu
         Vedeu.bind(:_geometry_left_) do |name|
           Vedeu::Move.by_name(Vedeu::Geometry, :left, name)
         end
+
+        Vedeu.bind_alias(:_view_left_, :_geometry_left_)
       end
 
       # Move the geometry right by one character.
       #
       # @example
       #   Vedeu.trigger(:_geometry_right_, name)
+      #   Vedeu.trigger(:_view_right_, name)
       #
       # @return [TrueClass]
       # @see Vedeu::Move
@@ -163,12 +169,15 @@ module Vedeu
         Vedeu.bind(:_geometry_right_) do |name|
           Vedeu::Move.by_name(Vedeu::Geometry, :right, name)
         end
+
+        Vedeu.bind_alias(:_view_right_, :_geometry_right_)
       end
 
       # Move the geometry up by one character.
       #
       # @example
       #   Vedeu.trigger(:_geometry_up_, name)
+      #   Vedeu.trigger(:_view_up_, name)
       #
       # @return [TrueClass]
       # @see Vedeu::Move
@@ -176,6 +185,8 @@ module Vedeu
         Vedeu.bind(:_geometry_up_) do |name|
           Vedeu::Move.by_name(Vedeu::Geometry, :up, name)
         end
+
+        Vedeu.bind_alias(:_view_up_, :_geometry_up_)
       end
 
     end # Movement

--- a/lib/vedeu/bindings/visibility.rb
+++ b/lib/vedeu/bindings/visibility.rb
@@ -55,17 +55,12 @@ module Vedeu
           Vedeu::Cursor.hide_cursor(name)
         end
 
-        # @todo Remove this aliasing event. (GL 2015-07-26)
-        Vedeu.bind(:_cursor_hide_) do |name|
-          Vedeu.trigger(:_hide_cursor_, name)
-        end
+        Vedeu.bind_alias(:_cursor_hide_, :_hide_cursor_)
       end
 
       # @see Vedeu::Group#hide
       def hide_group!
-        Vedeu.bind(:_hide_group_) do |name|
-          Vedeu::Group.hide_group(name)
-        end
+        Vedeu.bind(:_hide_group_) { |name| Vedeu::Group.hide_group(name) }
       end
 
       # Hiding an interface.
@@ -95,17 +90,12 @@ module Vedeu
           Vedeu::Cursor.show_cursor(name)
         end
 
-        # @todo Remove this aliasing event. (GL 2015-07-26)
-        Vedeu.bind(:_cursor_show_) do |name|
-          Vedeu.trigger(:_show_cursor_, name)
-        end
+        Vedeu.bind_alias(:_cursor_show_, :_show_cursor_)
       end
 
       # @see Vedeu::Group#show
       def show_group!
-        Vedeu.bind(:_show_group_) do |name|
-          Vedeu::Group.show_group(name)
-        end
+        Vedeu.bind(:_show_group_) { |name| Vedeu::Group.show_group(name) }
       end
 
       # Showing an interface.

--- a/lib/vedeu/cursor/cursor.rb
+++ b/lib/vedeu/cursor/cursor.rb
@@ -99,7 +99,7 @@ module Vedeu
     def hide
       super
 
-      visibility
+      Vedeu::Output.render(visibility)
     end
 
     # Return the position of this cursor.
@@ -119,7 +119,7 @@ module Vedeu
     def show
       super
 
-      visibility
+      Vedeu::Output.render(visibility)
     end
 
     private

--- a/lib/vedeu/events/event.rb
+++ b/lib/vedeu/events/event.rb
@@ -93,7 +93,7 @@ module Vedeu
       # @param name [Symbol]
       # @return [Boolean]
       def bound?(name)
-        Vedeu.events.registered?(name)
+        Vedeu.events.registered?(name) || Vedeu::EventAliases.registered?(name)
       end
 
       # Unbind events from a named handler.

--- a/lib/vedeu/events/event_aliases.rb
+++ b/lib/vedeu/events/event_aliases.rb
@@ -1,5 +1,8 @@
 module Vedeu
 
+  # Allows the storing of event aliases. Each alias can contain multiple event
+  # names.
+  #
   module EventAliases
 
     extend self

--- a/lib/vedeu/events/event_aliases.rb
+++ b/lib/vedeu/events/event_aliases.rb
@@ -1,0 +1,84 @@
+module Vedeu
+
+  module EventAliases
+
+    extend self
+
+    # @param alias_name [Symbol]
+    # @param event_name [Symbol]
+    # @return [Hash<Symbol => Array<Symbol>>]
+    def add(alias_name, event_name)
+      storage[alias_name] << event_name
+    end
+    alias_method :bind_alias, :add
+
+    # Return a boolean indicating whether the storage is empty.
+    #
+    # @return [Boolean]
+    def empty?
+      storage.empty?
+    end
+
+    # @param alias_name [Symbol]
+    # @return [Array<Symbol>]
+    def find(alias_name)
+      storage[alias_name]
+    end
+
+    # Returns a boolean indicating whether the alias is registered.
+    #
+    # @param alias_name [Symbol]
+    # @return [Boolean]
+    def registered?(alias_name)
+      return false if alias_name.nil? || alias_name.empty?
+      return false if empty?
+
+      storage.include?(alias_name)
+    end
+
+    # @param alias_name [Symbol]
+    # @return [FalseClass|Hash<Symbol => Array<Symbol>>]
+    def remove(alias_name)
+      return false if empty?
+      return false unless registered?(alias_name)
+
+      storage.delete(alias_name)
+      storage
+    end
+    alias_method :unbind_alias, :remove
+
+    # @return [Hash<Symbol => Array<Symbol>>]
+    def reset
+      @storage = in_memory
+    end
+    alias_method :reset!, :reset
+
+    # Access to the storage for this repository.
+    #
+    # @return [Hash<Symbol => Array<Symbol>>]
+    def storage
+      @storage ||= in_memory
+    end
+
+    # @param alias_name [Symbol]
+    # @param args [void]
+    # @return [FalseClass|Array<void>|void]
+    def trigger(alias_name, *args)
+      return [] unless registered?(alias_name)
+
+      storage[alias_name].map do |event_name|
+        Vedeu.log(type: :debug, message: "#{event_name}")
+        Vedeu::Trigger.trigger(event_name, *args)
+      end
+    end
+
+    private
+
+    # @return [Hash<Symbol => Array<Symbol>>]
+    def in_memory
+      Hash.new { |hash, key| hash[key] = [] }
+    end
+
+  end # EventAliases
+
+end # Vedeu

--- a/lib/vedeu/events/trigger.rb
+++ b/lib/vedeu/events/trigger.rb
@@ -66,9 +66,17 @@ module Vedeu
     #
     # @return [Array|Array<Vedeu::Event>]
     def registered_events
-      return [] unless repository.registered?(name)
+      if repository.registered?(name)
+        repository.find(name)
 
-      repository.find(name)
+      else
+        Vedeu::EventAliases.find(name).map do |event_name|
+          Vedeu::Trigger.trigger(event_name, *args)
+        end
+
+        []
+
+      end
     end
 
   end # Trigger

--- a/lib/vedeu/output/presentation.rb
+++ b/lib/vedeu/output/presentation.rb
@@ -1,3 +1,6 @@
+require 'vedeu/output/presentation/colour'
+require 'vedeu/output/presentation/style'
+
 module Vedeu
 
   # This module allows the sharing of presentation concerns between the models:
@@ -5,142 +8,8 @@ module Vedeu
   #
   module Presentation
 
-    # When the background colour for the model exists, return it, otherwise
-    # returns the parent background colour, or an empty Vedeu::Background.
-    #
-    # @return [Vedeu::Background]
-    def background
-      @background ||= if colour
-                        colour.background
-
-                      else
-                        parent_background
-
-                      end
-    end
-
-    # Allows the setting of the background colour by coercing the given value
-    # into a Vedeu::Background colour.
-    #
-    # @return [Vedeu::Background]
-    def background=(value)
-      self.colour = Vedeu::Colour.coerce(
-        background: Vedeu::Background.coerce(value),
-        foreground: colour.foreground)
-    end
-
-    # @return [Vedeu::Colour]
-    def colour
-      @colour ||= if attributes[:colour]
-                    Vedeu::Colour.coerce(attributes[:colour])
-
-                  elsif parent_colour
-                    Vedeu::Colour.coerce(parent_colour)
-
-                  else
-                    Vedeu::Colour.new
-
-                  end
-    end
-
-    # Allows the setting of the model's colour by coercing the given value into
-    # a Vedeu::Colour.
-    #
-    # @return [Vedeu::Colour]
-    def colour=(value)
-      @colour = attributes[:colour] = Vedeu::Colour.coerce(value)
-    end
-
-    # When the foreground colour for the model exists, return it, otherwise
-    # returns the parent foreground colour, or an empty Vedeu::Foreground.
-    #
-    # @return [Vedeu::Foreground]
-    def foreground
-      @foreground ||= if colour
-                        colour.foreground
-
-                      else
-                        parent_foreground
-
-                      end
-    end
-
-    # Allows the setting of the foreground colour by coercing the given value
-    # into a Vedeu::Foreground colour.
-    #
-    # @return [Vedeu::Foreground]
-    def foreground=(value)
-      self.colour = Vedeu::Colour.coerce(
-        foreground: Vedeu::Foreground.coerce(value),
-        background: colour.background)
-    end
-
-    # When a parent colour is available, returns the parent background colour,
-    # otherwise an empty Vedeu::Background.
-    #
-    # @return [Vedeu::Background]
-    def parent_background
-      if parent_colour
-        parent_colour.background
-
-      else
-        Vedeu::Background.new
-
-      end
-    end
-
-    # Returns the parent colour when available or NilClass.
-    #
-    # @return [String|NilClass]
-    def parent_colour
-      parent.colour if parent
-    end
-
-    # When a parent colour is available, returns the parent foreground colour,
-    # otherwise an empty Vedeu::Foreground.
-    #
-    # @return [Vedeu::Foreground]
-    def parent_foreground
-      if parent_colour
-        parent_colour.foreground
-
-      else
-        Vedeu::Foreground.new
-
-      end
-    end
-
-    # Returns the parent style when available or NilClass.
-    #
-    # @return [String|NilClass]
-    def parent_style
-      if parent
-        parent.style
-
-      else
-        Vedeu::Style.new
-
-      end
-    end
-
-    # @return [Vedeu::Style]
-    def style
-      @style ||= if attributes[:style]
-                   Vedeu::Style.coerce(attributes[:style])
-
-                 elsif parent_style
-                   Vedeu::Style.coerce(parent_style)
-
-                 else
-                   Vedeu::Style.new
-
-                 end
-    end
-
-    # @return [Vedeu::Style]
-    def style=(value)
-      @style = Vedeu::Style.coerce(value)
-    end
+    include Vedeu::Presentation::Colour
+    include Vedeu::Presentation::Style
 
     # Converts the colours and styles to escape sequences, and when the parent
     # model has previously set the colour and style, reverts back to that for

--- a/lib/vedeu/output/presentation/colour.rb
+++ b/lib/vedeu/output/presentation/colour.rb
@@ -1,0 +1,116 @@
+module Vedeu
+
+  module Presentation
+
+    module Colour
+
+      # When the background colour for the model exists, return it, otherwise
+      # returns the parent background colour, or an empty Vedeu::Background.
+      #
+      # @return [Vedeu::Background]
+      def background
+        @background ||= if colour
+                          colour.background
+
+                        else
+                          parent_background
+
+                        end
+      end
+
+      # Allows the setting of the background colour by coercing the given value
+      # into a Vedeu::Background colour.
+      #
+      # @return [Vedeu::Background]
+      def background=(value)
+        self.colour = Vedeu::Colour.coerce(
+          background: Vedeu::Background.coerce(value),
+          foreground: colour.foreground)
+      end
+
+      # @return [Vedeu::Colour]
+      def colour
+        @colour ||= if attributes[:colour]
+                      Vedeu::Colour.coerce(attributes[:colour])
+
+                    elsif parent_colour
+                      Vedeu::Colour.coerce(parent_colour)
+
+                    else
+                      Vedeu::Colour.new
+
+                    end
+      end
+
+      # Allows the setting of the model's colour by coercing the given value
+      # into a Vedeu::Colour.
+      #
+      # @return [Vedeu::Colour]
+      def colour=(value)
+        @colour = attributes[:colour] = Vedeu::Colour.coerce(value)
+      end
+
+      # When the foreground colour for the model exists, return it, otherwise
+      # returns the parent foreground colour, or an empty Vedeu::Foreground.
+      #
+      # @return [Vedeu::Foreground]
+      def foreground
+        @foreground ||= if colour
+                          colour.foreground
+
+                        else
+                          parent_foreground
+
+                        end
+      end
+
+      # Allows the setting of the foreground colour by coercing the given value
+      # into a Vedeu::Foreground colour.
+      #
+      # @return [Vedeu::Foreground]
+      def foreground=(value)
+        self.colour = Vedeu::Colour.coerce(
+          foreground: Vedeu::Foreground.coerce(value),
+          background: colour.background)
+      end
+
+      # When a parent colour is available, returns the parent background colour,
+      # otherwise an empty Vedeu::Background.
+      #
+      # @return [Vedeu::Background]
+      def parent_background
+        if parent_colour
+          parent_colour.background
+
+        else
+          Vedeu::Background.new
+
+        end
+      end
+
+      # Returns the parent colour when available or NilClass.
+      #
+      # @return [String|NilClass]
+      def parent_colour
+        parent.colour if parent
+      end
+
+      # When a parent colour is available, returns the parent foreground colour,
+      # otherwise an empty Vedeu::Foreground.
+      #
+      # @return [Vedeu::Foreground]
+      def parent_foreground
+        if parent_colour
+          parent_colour.foreground
+
+        else
+          Vedeu::Foreground.new
+
+        end
+      end
+
+    end # Colour
+
+  end # Presentation
+
+end # Vedeu

--- a/lib/vedeu/output/presentation/colour.rb
+++ b/lib/vedeu/output/presentation/colour.rb
@@ -2,6 +2,8 @@ module Vedeu
 
   module Presentation
 
+    # Provides colour related presentation behaviour.
+    #
     module Colour
 
       # When the background colour for the model exists, return it, otherwise

--- a/lib/vedeu/output/presentation/style.rb
+++ b/lib/vedeu/output/presentation/style.rb
@@ -1,0 +1,43 @@
+module Vedeu
+
+  module Presentation
+
+    module Style
+
+      # Returns the parent style when available or NilClass.
+      #
+      # @return [String|NilClass]
+      def parent_style
+        if parent
+          parent.style
+
+        else
+          Vedeu::Style.new
+
+        end
+      end
+
+      # @return [Vedeu::Style]
+      def style
+        @style ||= if attributes[:style]
+                     Vedeu::Style.coerce(attributes[:style])
+
+                   elsif parent_style
+                     Vedeu::Style.coerce(parent_style)
+
+                   else
+                     Vedeu::Style.new
+
+                   end
+      end
+
+      # @return [Vedeu::Style]
+      def style=(value)
+        @style = Vedeu::Style.coerce(value)
+      end
+
+    end # Style
+
+  end # Presentation
+
+end # Vedeu

--- a/lib/vedeu/output/presentation/style.rb
+++ b/lib/vedeu/output/presentation/style.rb
@@ -2,6 +2,8 @@ module Vedeu
 
   module Presentation
 
+    # Provides style related presentation behaviour.
+    #
     module Style
 
       # Returns the parent style when available or NilClass.

--- a/lib/vedeu/output/renderers.rb
+++ b/lib/vedeu/output/renderers.rb
@@ -34,6 +34,8 @@ module Vedeu
         end
       end
       threads.each(&:join)
+
+      output
     end
 
     # Adds the given renderer class(es) to the list of renderers.

--- a/lib/vedeu/repositories/repository.rb
+++ b/lib/vedeu/repositories/repository.rb
@@ -172,11 +172,6 @@ module Vedeu
 
     private
 
-    # @return [Hash]
-    def in_memory
-      {}
-    end
-
     # @return [String]
     def log_store(model)
       type = registered?(model.name) ? :update : :create

--- a/lib/vedeu/repositories/store.rb
+++ b/lib/vedeu/repositories/store.rb
@@ -69,6 +69,11 @@ module Vedeu
     end
     alias_method :all, :storage
 
+    # @return [Hash]
+    def in_memory
+      {}
+    end
+
   end # Store
 
 end # Vedeu

--- a/test/lib/vedeu/api_test.rb
+++ b/test/lib/vedeu/api_test.rb
@@ -20,8 +20,11 @@ module Vedeu
     it { Vedeu.must_respond_to(:render) }
     it { Vedeu.must_respond_to(:views) }
     it { Vedeu.must_respond_to(:bind) }
+    it { Vedeu.must_respond_to(:bind_alias) }
     it { Vedeu.must_respond_to(:bound?) }
     it { Vedeu.must_respond_to(:unbind) }
+    it { Vedeu.must_respond_to(:unbind_alias) }
+    it { Vedeu.must_respond_to(:events) }
     it { Vedeu.must_respond_to(:focus) }
     it { Vedeu.must_respond_to(:focus_by_name) }
     it { Vedeu.must_respond_to(:focussed?) }

--- a/test/lib/vedeu/events/event_aliases_test.rb
+++ b/test/lib/vedeu/events/event_aliases_test.rb
@@ -1,0 +1,118 @@
+require 'test_helper'
+
+module Vedeu
+
+	describe EventAliases do
+
+    let(:described) { Vedeu::EventAliases }
+
+    before do
+      Vedeu::EventAliases.reset
+    end
+    after do
+      Vedeu::Bindings.setup!
+    end
+
+    describe '.add' do
+      let(:alias_name) { :alias_test }
+      let(:event_name) { :event_test }
+
+      subject { described.add(alias_name, event_name) }
+
+      it { described.must_respond_to(:bind_alias) }
+
+      context 'when the alias is already registered' do
+        before { Vedeu::EventAliases.add(:alias_test, :event_test) }
+
+        it { subject.must_equal([:event_test, :event_test]) }
+      end
+
+      context 'when the alias is not already registered' do
+        it { subject.must_equal([:event_test]) }
+      end
+    end
+
+    describe '.empty?' do
+      subject { described.empty? }
+
+      context 'when no aliases are registered' do
+        before { Vedeu::EventAliases.reset }
+
+        it { subject.must_equal(true) }
+      end
+
+      context 'when aliases are registered' do
+        before { Vedeu::EventAliases.add(:alias_test, :event_test) }
+
+        it { subject.must_equal(false) }
+      end
+    end
+
+    describe '.registered?' do
+      let(:alias_name) { :alias_test }
+
+      subject { described.registered?(alias_name) }
+
+      context 'when the alias is registered' do
+        before { Vedeu::EventAliases.add(:alias_test, :event_test) }
+
+        it { subject.must_equal(true) }
+      end
+
+      context 'when the alias is not registered' do
+        it { subject.must_equal(false) }
+      end
+    end
+
+    describe '.remove' do
+      let(:alias_name) { :alias_test }
+
+      before { Vedeu::EventAliases.reset }
+
+      subject { described.remove(alias_name) }
+
+      it { described.must_respond_to(:unbind_alias) }
+
+      context 'when no aliases are registered' do
+        it { subject.must_equal(false) }
+      end
+
+      context 'when the alias is not registered' do
+        before { Vedeu::EventAliases.add(:other_alias_test, :event_test) }
+
+        it { subject.must_equal(false) }
+      end
+
+      context 'when the alias is registered' do
+        before { Vedeu::EventAliases.add(:alias_test, :event_test) }
+
+        it { subject.must_equal({}) }
+      end
+    end
+
+    describe '.reset' do
+      subject { described.reset }
+
+      it { described.must_respond_to(:reset!) }
+
+      it { subject.must_equal({}) }
+    end
+
+    describe '.storage' do
+      before { Vedeu::EventAliases.reset }
+
+      subject { described.storage }
+
+      it { subject.must_equal({}) }
+    end
+
+    describe '.trigger' do
+      let(:alias_name) {}
+      let(:args)       {}
+
+      subject { described.trigger(alias_name, *args) }
+    end
+
+	end # EventAliases
+
+end # Vedeu

--- a/test/lib/vedeu/output/presentation/colour_test.rb
+++ b/test/lib/vedeu/output/presentation/colour_test.rb
@@ -1,0 +1,165 @@
+require 'test_helper'
+
+module Vedeu
+
+  class ParentPresentationTestClass
+    include Vedeu::Presentation
+
+    def parent
+      nil
+    end
+
+    def attributes
+      {
+        colour: { background: '#330000', foreground: '#00aadd' },
+        style:  ['bold']
+      }
+    end
+  end
+
+  class PresentationTestClass
+    include Vedeu::Presentation
+
+    attr_reader :attributes
+
+    def initialize(attributes = {})
+      @attributes = attributes
+    end
+
+    def parent
+      Vedeu::ParentPresentationTestClass.new
+    end
+
+  end # PresentationTestClass
+
+  module Presentation
+
+    describe Colour do
+
+      let(:includer) { Vedeu::PresentationTestClass.new(attributes) }
+      let(:attributes) {
+        {
+          colour: { background: background, foreground: foreground },
+          style:  ['bold']
+        }
+      }
+      let(:background) { '#000033' }
+      let(:foreground) { '#aadd00' }
+
+      describe '#background' do
+        subject { includer.background }
+
+        it { subject.must_be_instance_of(Vedeu::Background) }
+        it { subject.colour.must_equal('#000033') }
+
+        context 'no background value' do
+          let(:attributes) { {} }
+          let(:background) {}
+
+          it { subject.must_be_instance_of(Vedeu::Background) }
+          it { subject.colour.must_equal('#330000') }
+        end
+      end
+
+      describe '#background=' do
+        subject { includer.background = '#987654' }
+
+        it {
+          includer.colour.background.colour.must_equal('#000033')
+          subject
+          includer.colour.background.colour.must_equal('#987654')
+        }
+
+        it { subject.must_equal('#987654') }
+      end
+
+      describe '#foreground' do
+        subject { includer.foreground }
+
+        it { subject.must_be_instance_of(Vedeu::Foreground) }
+        it { subject.colour.must_equal('#aadd00') }
+
+        context 'no foreground value' do
+          let(:attributes) { {} }
+          let(:foreground) {}
+
+          it { subject.must_be_instance_of(Vedeu::Foreground) }
+          it { subject.colour.must_equal('#00aadd') }
+        end
+      end
+
+      describe '#foreground=' do
+        subject { includer.foreground = '#123456' }
+
+        it {
+          includer.colour.foreground.colour.must_equal('#aadd00')
+          subject
+          includer.colour.foreground.colour.must_equal('#123456')
+        }
+
+        it { subject.must_equal('#123456') }
+      end
+
+      describe '#parent_background' do
+        subject { includer.parent_background }
+
+        it { subject.must_be_instance_of(Vedeu::Background) }
+        it { subject.colour.must_equal('#330000') }
+
+        context 'when no parent colour is set' do
+          before { includer.stubs(:parent).returns(nil) }
+
+          it { subject.colour.must_equal('') }
+        end
+      end
+
+      describe '#parent_colour' do
+        subject { includer.parent_colour }
+
+        context 'when a parent is available' do
+          it { subject.must_be_instance_of(Vedeu::Colour) }
+          it { subject.background.must_be_instance_of(Vedeu::Background) }
+          it { subject.foreground.must_be_instance_of(Vedeu::Foreground) }
+        end
+
+        context 'when a parent is not available' do
+          before { includer.stubs(:parent).returns(nil) }
+
+          it { subject.must_equal(nil) }
+        end
+      end
+
+      describe '#parent_foreground' do
+        subject { includer.parent_foreground }
+
+        it { subject.must_be_instance_of(Vedeu::Foreground) }
+        it { subject.colour.must_equal('#00aadd') }
+
+        context 'when no parent colour is set' do
+          before { includer.stubs(:parent).returns(nil) }
+
+          it { subject.colour.must_equal('') }
+        end
+      end
+
+      describe '#colour' do
+        subject { includer.colour }
+
+        it { subject.must_be_instance_of(Vedeu::Colour) }
+      end
+
+      describe '#colour=' do
+        let(:colour) {
+          Vedeu::Colour.new(foreground: '#00ff00', background: '#000000')
+        }
+
+        subject { includer.colour = (colour) }
+
+        it { subject.must_be_instance_of(Vedeu::Colour) }
+      end
+
+    end # Colour
+
+  end # Presentation
+
+end # Vedeu

--- a/test/lib/vedeu/output/presentation/style_test.rb
+++ b/test/lib/vedeu/output/presentation/style_test.rb
@@ -1,0 +1,83 @@
+require 'test_helper'
+
+module Vedeu
+
+  class ParentPresentationTestClass
+    include Vedeu::Presentation
+
+    def parent
+      nil
+    end
+
+    def attributes
+      {
+        colour: { background: '#330000', foreground: '#00aadd' },
+        style:  ['bold']
+      }
+    end
+  end
+
+  class PresentationTestClass
+    include Vedeu::Presentation
+
+    attr_reader :attributes
+
+    def initialize(attributes = {})
+      @attributes = attributes
+    end
+
+    def parent
+      Vedeu::ParentPresentationTestClass.new
+    end
+
+  end # PresentationTestClass
+
+  module Presentation
+
+    describe Style do
+
+      let(:includer) { Vedeu::PresentationTestClass.new(attributes) }
+      let(:attributes) {
+        {
+          colour: { background: background, foreground: foreground },
+          style:  ['bold']
+        }
+      }
+      let(:background) { '#000033' }
+      let(:foreground) { '#aadd00' }
+
+      describe '#parent_style' do
+        subject { includer.parent_style }
+
+        it { subject.must_be_instance_of(Vedeu::Style) }
+
+        context 'when a parent is available' do
+          it { subject.value.must_equal(['bold']) }
+        end
+
+        context 'when a parent is not available' do
+          before { includer.stubs(:parent).returns(nil) }
+
+          it { subject.value.must_equal(nil) }
+        end
+      end
+
+      describe '#style' do
+        subject { includer.style }
+
+        it { subject.must_be_instance_of(Vedeu::Style) }
+      end
+
+      describe '#style=' do
+        let(:style) { Vedeu::Style.new('normal') }
+
+        subject { includer.style = (style) }
+
+        it { subject.must_be_instance_of(Vedeu::Style) }
+      end
+
+    end # Style
+
+  end # Presentation
+
+end # Vedeu

--- a/test/lib/vedeu/output/presentation_test.rb
+++ b/test/lib/vedeu/output/presentation_test.rb
@@ -44,167 +44,27 @@ module Vedeu
     let(:background) { '#000033' }
     let(:foreground) { '#aadd00' }
 
-    describe '#background' do
-      subject { includer.background }
-
-      it { subject.must_be_instance_of(Vedeu::Background) }
-      it { subject.colour.must_equal('#000033') }
-
-      context 'no background value' do
-        let(:attributes) { {} }
-        let(:background) {}
-
-        it { subject.must_be_instance_of(Vedeu::Background) }
-        it { subject.colour.must_equal('#330000') }
-      end
-    end
-
-    describe '#background=' do
-      subject { includer.background = '#987654' }
-
-      it {
-        includer.colour.background.colour.must_equal('#000033')
-        subject
-        includer.colour.background.colour.must_equal('#987654')
-      }
-
-      it { subject.must_equal('#987654') }
-    end
-
-    describe '#foreground' do
-      subject { includer.foreground }
-
-      it { subject.must_be_instance_of(Vedeu::Foreground) }
-      it { subject.colour.must_equal('#aadd00') }
-
-      context 'no foreground value' do
-        let(:attributes) { {} }
-        let(:foreground) {}
-
-        it { subject.must_be_instance_of(Vedeu::Foreground) }
-        it { subject.colour.must_equal('#00aadd') }
-      end
-    end
-
-    describe '#foreground=' do
-      subject { includer.foreground = '#123456' }
-
-      it {
-        includer.colour.foreground.colour.must_equal('#aadd00')
-        subject
-        includer.colour.foreground.colour.must_equal('#123456')
-      }
-
-      it { subject.must_equal('#123456') }
-    end
-
-    describe '#parent_background' do
-      subject { includer.parent_background }
-
-      it { subject.must_be_instance_of(Vedeu::Background) }
-      it { subject.colour.must_equal('#330000') }
-
-      context 'when no parent colour is set' do
-        before { includer.stubs(:parent).returns(nil) }
-
-        it { subject.colour.must_equal('') }
-      end
-    end
-
-    describe '#parent_colour' do
-      subject { includer.parent_colour }
-
-      context 'when a parent is available' do
-        it { subject.must_be_instance_of(Vedeu::Colour) }
-        it { subject.background.must_be_instance_of(Vedeu::Background) }
-        it { subject.foreground.must_be_instance_of(Vedeu::Foreground) }
-      end
-
-      context 'when a parent is not available' do
-        before { includer.stubs(:parent).returns(nil) }
-
-        it { subject.must_equal(nil) }
-      end
-    end
-
-    describe '#parent_foreground' do
-      subject { includer.parent_foreground }
-
-      it { subject.must_be_instance_of(Vedeu::Foreground) }
-      it { subject.colour.must_equal('#00aadd') }
-
-      context 'when no parent colour is set' do
-        before { includer.stubs(:parent).returns(nil) }
-
-        it { subject.colour.must_equal('') }
-      end
-    end
-
-    describe '#colour' do
-      subject { includer.colour }
-
-      it { subject.must_be_instance_of(Vedeu::Colour) }
-    end
-
-    describe '#colour=' do
-      let(:colour) { Colour.new(foreground: '#00ff00', background: '#000000') }
-
-      subject { includer.colour = (colour) }
-
-      it { subject.must_be_instance_of(Colour) }
-    end
-
-    describe '#parent_style' do
-      subject { includer.parent_style }
-
-      it { subject.must_be_instance_of(Vedeu::Style) }
-
-      context 'when a parent is available' do
-        it { subject.value.must_equal(['bold']) }
-      end
-
-      context 'when a parent is not available' do
-        before { includer.stubs(:parent).returns(nil) }
-
-        it { subject.value.must_equal(nil) }
-      end
-    end
-
-    describe '#style' do
-      subject { includer.style }
-
-      it { subject.must_be_instance_of(Vedeu::Style) }
-    end
-
-    describe '#style=' do
-      let(:style) { Style.new('normal') }
-
-      subject { includer.style = (style) }
-
-      it { subject.must_be_instance_of(Style) }
-    end
-
     describe '#to_s' do
       let(:line) {
         Vedeu::Line.new(streams: [],
                         parent:  Vedeu::Interface.new,
                         colour:  line_colour,
-                        style:   Style.new('normal'))
+                        style:   Vedeu::Style.new('normal'))
       }
       let(:line_colour) {
-        Colour.new(foreground: '#00ff00', background: '#000000')
+        Vedeu::Colour.new(foreground: '#00ff00', background: '#000000')
       }
       let(:stream) {
-        Stream.new(value: stream_value,
+        Vedeu::Stream.new(value: stream_value,
                    parent: line,
                    colour: stream_colour,
                    style: stream_style)
       }
       let(:stream_value)  { 'Some text' }
       let(:stream_colour) {
-        Colour.new(foreground: '#ff0000', background: '#000000')
+        Vedeu::Colour.new(foreground: '#ff0000', background: '#000000')
       }
-      let(:stream_style)  { Style.new(:underline) }
+      let(:stream_style)  { Vedeu::Style.new(:underline) }
 
       it { includer.must_respond_to(:to_str) }
 

--- a/test/lib/vedeu/output/renderers_test.rb
+++ b/test/lib/vedeu/output/renderers_test.rb
@@ -49,7 +49,7 @@ module Vedeu
         context 'when no renderers are defined' do
           let(:renderers) {}
 
-          it { subject.must_equal([]) }
+          it { subject.must_equal(output) }
         end
       end
     end
@@ -64,12 +64,22 @@ module Vedeu
 
       subject { described.render(output) }
 
-      it { subject.must_be_instance_of(Array) }
+      # it { subject.must_be_instance_of(Array) }
 
       it {
         DummyRenderer.expects(:render).with(output)
         subject
       }
+
+      context 'when there is content' do
+        let(:output) { Vedeu::Escape.new(Vedeu::Esc.hide_cursor) }
+
+        it { subject.must_be_instance_of(Vedeu::Escape) }
+      end
+
+      context 'when there is no content' do
+        it { subject.must_be_instance_of(NilClass) }
+      end
     end
 
     describe '.renderer' do


### PR DESCRIPTION
EventAliases allow the aliasing of event names for convenience. A nice side-effect is that this mechanism can be used to group collections of events into a single event name to provide more terse code, but also unlock powerful behaviours.