### PR TITLE
Add minimal, interactive example using the DSL.

### DIFF
--- a/examples/hello_worlds.rb
+++ b/examples/hello_worlds.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+
+require 'vedeu'
+
+# An example application to demonstrate 'Hello World' and a minimum of
+# interactivity.  It uses the DSL-style of vedeu (not the full-flegded
+# MVC-approach).
+#
+# If you have cloned this repository from GitHub, you can run this example:
+#
+#     bundle exec ./examples/hello_worlds.rb
+#
+class HelloWorldsApp
+
+  Vedeu.bind(:_initialize_) { Vedeu.trigger(:_refresh_) }
+
+  Vedeu.configure do
+    # Empty configure block is needed.
+  end
+
+  Vedeu.interface :hello do
+    # Define all of the interface in one place.
+    background '#000000'
+    foreground '#00ff00'
+    geometry do
+      centred!
+      height   5
+      width    24
+    end
+    Vedeu.views do
+      view :hello do
+        lines do
+          line { centre 'Hello Worlds!', width: 24 }
+          line
+          line { centre "Press 'q' to exit,",     width: 24 }
+          line { centre " 'w' to switch worlds.", width: 24 }
+        end
+      end
+    end
+    keymap do
+      key('q') { Vedeu.exit }
+      key('w') { HelloWorldsApp.render_world }
+    end
+  end
+
+  def self.start(argv = ARGV)
+    Vedeu::Launcher.execute!(argv)
+  end
+
+  private
+
+  def self.render_world
+    # Immediately render this to screen.
+    Vedeu.render do
+      view :hello do
+        geometry do
+          centred!
+          height  5 + 2
+          width   24 + 2
+        end
+        border :hello do
+          colour foreground: ["#00ff00", "#000033", "#cddc39", "#03a9f4"].sample
+          title ["atlantis", "oceania", "utopia", "midgard", "middle-earth"].sample
+        end
+        lines do
+          line { centre 'Hello Worlds!', width: 24 }
+          line
+          line { centre "Press 'q' to exit,",     width: 24 }
+          line { centre " 'w' to switch worlds.", width: 24 }
+        end
+      end
+    end
+  end
+
+end # HelloWorldsApp
+
+HelloWorldsApp.start(ARGV)

--- a/examples/hello_worlds.rb
+++ b/examples/hello_worlds.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'bundler/setup'
 require 'vedeu'
 
 # An example application to demonstrate 'Hello World' and a minimum of
@@ -27,6 +28,7 @@ class HelloWorldsApp
       height   5
       width    24
     end
+    # (You usually specify the views outside the interface block).
     Vedeu.views do
       view :hello do
         lines do

--- a/examples/hello_worlds.rb
+++ b/examples/hello_worlds.rb
@@ -60,7 +60,7 @@ class HelloWorldsApp
           height  5 + 2
           width   24 + 2
         end
-        border :hello do
+        border do
           colour foreground: ["#00ff00", "#000033", "#cddc39", "#03a9f4"].sample
           title ["atlantis", "oceania", "utopia", "midgard", "middle-earth"].sample
         end


### PR DESCRIPTION
My take on a "Hello World" example, based on `test/support/hello_world.rb`.

Several things to note:
  * I prefer the `bundle exec` style of development, but have seen commits "preventing" this. Please state the preferred style.
  * Without the `configure` (ll 18) block the examples do not work for me. Should I open an issue for that?
  * Directly rendering seems dirty to me. Without knowing the internals I wonder if this is the correct (or viable) way.
  * Merged like this, it would bring a examples folder into the gem. I do actually like it if installed gems ship with examples (currently test/support/examples is not included in the gem, see gemspec), but probably you want to wait for a cleaner example or have a better one at hand yourself.
  * I think the next example should feature a (in memory) persisted object to interact with (e.g. a counter :) ). In the given example I only see this achievable with databases or global variables, which are considered to be 80s.