### PR TITLE
Fix Renderers::File.

### DIFF
--- a/lib/vedeu/output/compressor.rb
+++ b/lib/vedeu/output/compressor.rb
@@ -13,18 +13,21 @@ module Vedeu
 
       # @param (see #initialize)
       # @return [String]
-      def self.render(output)
-        new(output).render
+      def self.render(output, options = {})
+        new(output, options).render
       end
 
       # Returns a new instance of Vedeu::Output::Compressor.
       #
       # @param output [Array<Array<Vedeu::Views::Char>>]
+      # @param options [Hash]
+      # @option options compression [Boolean]
       # @return [Vedeu::Output::Compressor]
-      def initialize(output)
-        @output = output
-        @colour = ''
-        @style  = ''
+      def initialize(output, options = {})
+        @output  = output
+        @options = options
+        @colour  = ''
+        @style   = ''
       end
 
       # @note

--- a/lib/vedeu/output/renderers/file.rb
+++ b/lib/vedeu/output/renderers/file.rb
@@ -84,7 +84,7 @@ module Vedeu
       # @return [Hash]
       def defaults
         {
-          compression: false,
+          compression: Vedeu::Configuration.compression?,
           filename:    'out',
           timestamp:   false,
           write_file:  true,

--- a/lib/vedeu/output/renderers/file.rb
+++ b/lib/vedeu/output/renderers/file.rb
@@ -24,31 +24,54 @@ module Vedeu
 
       # Render a cleared output.
       #
+      # @param output [Vedeu::Models::Page]
+      # @param opts [Hash]
       # @return [String]
-      def clear(output = '')
-        ::File.write(filename, output) if write_file?
+      def clear(output = '', opts = {})
+        @options = options.merge!(opts)
 
-        output
+        ::File.write(filename, out(output)) if write_file?
+
+        out(output)
       end
 
       # @param output [Vedeu::Models::Page]
+      # @param opts [Hash]
       # @return [String]
-      def render(output)
-        ::File.write(filename, output) if write_file?
+      def render(output = '', opts = {})
+        @options = options.merge!(opts)
 
-        output
+        ::File.write(filename, out(output)) if write_file?
+
+        out(output)
       end
 
       private
 
+      def out(output)
+        if compress?
+          Vedeu::Output::Compressor.render(output, options)
+
+        else
+          output
+
+        end
+      end
+
       # @return [String]
       def filename
-        options[:filename] + "_#{timestamp}".freeze
+        options[:filename] + timestamp
       end
 
       # @return [Float]
       def timestamp
-        Time.now.to_f if options[:timestamp]
+        if options[:timestamp]
+          "_#{Time.now.to_f}".freeze
+
+        else
+          ''.freeze
+
+        end
       end
 
       # @return [Boolean]
@@ -61,9 +84,10 @@ module Vedeu
       # @return [Hash]
       def defaults
         {
-          filename:   'out',
-          timestamp:  false,
-          write_file: true,
+          compression: false,
+          filename:    'out',
+          timestamp:   false,
+          write_file:  true,
         }
       end
 

--- a/lib/vedeu/output/renderers/json.rb
+++ b/lib/vedeu/output/renderers/json.rb
@@ -20,7 +20,7 @@ module Vedeu
       def clear
         json = parse({})
 
-        super(json)
+        super(json, { compression: false })
 
         json
       end
@@ -30,7 +30,7 @@ module Vedeu
       def render(output)
         json = parse(output)
 
-        super(json)
+        super(json, { compression: false })
 
         json
       end

--- a/test/lib/vedeu/output/renderers/file_test.rb
+++ b/test/lib/vedeu/output/renderers/file_test.rb
@@ -11,12 +11,14 @@ module Vedeu
       let(:output)    { 'Some content...' }
       let(:options)   {
         {
-          filename:  filename,
-          timestamp: timestamp,
+          filename:    filename,
+          timestamp:   timestamp,
+          compression: compression,
         }
       }
-      let(:filename)  { 'vedeu_renderers_file' }
-      let(:timestamp) { false }
+      let(:filename)    { 'vedeu_renderers_file' }
+      let(:timestamp)   { false }
+      let(:compression) { false }
 
       before { ::File.stubs(:write) }
 

--- a/test/lib/vedeu/output/renderers/json_test.rb
+++ b/test/lib/vedeu/output/renderers/json_test.rb
@@ -15,6 +15,7 @@ module Vedeu
         ::File.stubs(:write)
         Vedeu.stubs(:height).returns(1)
         Vedeu.stubs(:width).returns(1)
+        # Vedeu::Configuration.stubs(:compression?).returns(false)
         Vedeu::Terminal::Buffer.reset
       end
 

--- a/test/lib/vedeu/output/renderers/json_test.rb
+++ b/test/lib/vedeu/output/renderers/json_test.rb
@@ -15,7 +15,6 @@ module Vedeu
         ::File.stubs(:write)
         Vedeu.stubs(:height).returns(1)
         Vedeu.stubs(:width).returns(1)
-        # Vedeu::Configuration.stubs(:compression?).returns(false)
         Vedeu::Terminal::Buffer.reset
       end
 


### PR DESCRIPTION
Previously, in #265; it was noted that some renderers were failing to render their content correctly. This is due to changes in the way the content was being provided to the renderers from `Models::Page`. I have addressed issues with `Renderers::File` and partly with both `Renderers::JSON` and `Renderers::HTML`.