### PR TITLE
Implement 'scrolling' for content (to top and to bottom).

### DIFF
--- a/docs/cursors.md
+++ b/docs/cursors.md
@@ -57,6 +57,8 @@ specified. If 'name' is unknown, using 'Vedeu.focus' will use the
 interface currently in focus.
 
 ### `:\_cursor_left\_`
+Moves the cursor one character left, unless the left-most position
+for the view or terminal is reached.
 
     Vedeu.trigger(:_cursor_left_, name)
     Vedeu.trigger(:_cursor_left_, Vedeu.focus)
@@ -67,6 +69,8 @@ interface currently in focus.
     Vedeu.trigger(:_cursor_down_, Vedeu.focus)
 
 ### `:\_cursor_up\_`
+Moves the cursor one line up, unless the top-most position for the
+view or terminal is reached.
 
     Vedeu.trigger(:_cursor_up_, name)
     Vedeu.trigger(:_cursor_up_, Vedeu.focus)
@@ -76,3 +80,18 @@ interface currently in focus.
     Vedeu.trigger(:_cursor_right_, name)
     Vedeu.trigger(:_cursor_right_, Vedeu.focus)
 
+### `:\_cursor_top\_`
+Moves the cursor to the top-most position for the view or terminal.
+If the view contains content, then this event will effectively scroll
+to the first line of the content.
+
+    Vedeu.trigger(:_cursor_top_, name)
+    Vedeu.trigger(:_cursor_top_, Vedeu.focus)
+
+### `:\_cursor_bottom\_`
+Moves the cursor to the bottom-most position for the view or terminal.
+If the view contains content, then this event will effectively scroll
+to the last line of the content.
+
+    Vedeu.trigger(:_cursor_bottom_, name)
+    Vedeu.trigger(:_cursor_bottom_, Vedeu.focus)

--- a/examples/dsl_alignment.rb
+++ b/examples/dsl_alignment.rb
@@ -8,8 +8,8 @@ class AlignmentApp
   Vedeu.bind(:_initialize_) { Vedeu.trigger(:_refresh_) }
 
   Vedeu.configure do
-    log './tmp/alignment.log'
-    renderers Vedeu::Renderers::File.new(filename: './tmp/alignment.out')
+    log '/tmp/alignment.log'
+    renderers Vedeu::Renderers::File.new(filename: '/tmp/alignment.out')
   end
 
   Vedeu.interface :top_left_view do

--- a/examples/dsl_editor.rb
+++ b/examples/dsl_editor.rb
@@ -8,8 +8,8 @@ class EditorApp
   Vedeu.bind(:_initialize_) { Vedeu.trigger(:_refresh_) }
 
   Vedeu.configure do
-    log './tmp/editor.log'
-    renderers Vedeu::Renderers::File.new(filename: './tmp/editor.out')
+    log '/tmp/editor.log'
+    renderers Vedeu::Renderers::File.new(filename: '/tmp/editor.out')
     fake!
   end
 

--- a/examples/dsl_hello_worlds.rb
+++ b/examples/dsl_hello_worlds.rb
@@ -21,7 +21,7 @@ class HelloWorldsApp
   # Add specific configuration for the client application.
   #
   # Vedeu.configure do
-  #   log './tmp/hello_worlds.log'
+  #   log '/tmp/hello_worlds.log'
   # end
 
   Vedeu.interface :hello do

--- a/examples/dsl_horizontal_alignment.rb
+++ b/examples/dsl_horizontal_alignment.rb
@@ -64,8 +64,8 @@ class HorizontalAlignmentApp
   Vedeu.bind(:_initialize_) { Vedeu.trigger(:_refresh_) }
 
   Vedeu.configure do
-    log './tmp/horizontal_alignment.log'
-    renderers Vedeu::Renderers::File.new(filename: './tmp/horizontal_alignment.out')
+    log '/tmp/horizontal_alignment.log'
+    renderers Vedeu::Renderers::File.new(filename: '/tmp/horizontal_alignment.out')
   end
 
   Vedeu.interface :left_interface do

--- a/examples/dsl_vertical_alignment.rb
+++ b/examples/dsl_vertical_alignment.rb
@@ -64,8 +64,8 @@ class VerticalAlignmentApp
   Vedeu.bind(:_initialize_) { Vedeu.trigger(:_refresh_) }
 
   Vedeu.configure do
-    log './tmp/vertical_alignment.log'
-    renderers Vedeu::Renderers::File.new(filename: './tmp/vertical_alignment.out')
+    log '/tmp/vertical_alignment.log'
+    renderers Vedeu::Renderers::File.new(filename: '/tmp/vertical_alignment.out')
   end
 
   Vedeu.interface :top_interface do

--- a/lib/vedeu/buffers/buffer.rb
+++ b/lib/vedeu/buffers/buffer.rb
@@ -123,6 +123,26 @@ module Vedeu
         end
       end
 
+      # Returns the number of lines of content for the buffer or 0 if
+      # the buffer is empty.
+      #
+      # @return [Fixnum]
+      def size
+        if back?
+          back.lines.size
+
+        elsif front?
+          front.lines.size
+
+        elsif previous?
+          previous.lines.size
+
+        else
+          0
+
+        end
+      end
+
       private
 
       # Returns the default options/attributes for this class.

--- a/lib/vedeu/cursors/cursor.rb
+++ b/lib/vedeu/cursors/cursor.rb
@@ -212,12 +212,12 @@ module Vedeu
 
       # @return [Fixnum]
       def ox
-        @ox < 0 ? 0 : @ox
+        @ox = @ox < 0 ? 0 : @ox
       end
 
       # @return [Fixnum]
       def oy
-        @oy < 0 ? 0 : @oy
+        @oy = @oy < 0 ? 0 : @oy
       end
 
       # Return the position of this cursor.

--- a/lib/vedeu/cursors/cursor.rb
+++ b/lib/vedeu/cursors/cursor.rb
@@ -382,6 +382,18 @@ module Vedeu
     Vedeu.trigger(:_refresh_cursor_, name)
   end
 
+  # See {file:docs/cursors.md}
+  Vedeu.bind(:_cursor_top_) do |name|
+    Vedeu.trigger(:_cursor_reposition_, name, 0, 0)
+  end
+
+  # See {file:docs/cursors.md}
+  Vedeu.bind(:_cursor_bottom_) do |name|
+    count = Vedeu.buffers.by_name(name).size
+
+    Vedeu.trigger(:_cursor_reposition_, name, count, 0)
+  end
+
   # :nocov:
 
 end # Vedeu

--- a/lib/vedeu/input/translator.rb
+++ b/lib/vedeu/input/translator.rb
@@ -108,6 +108,7 @@ module Vedeu
     "\e[3~" => :delete,
     "\u232B" => :delete,
     "\e[F" => :end,
+    "\eOF" => :end,
     "\r" => :enter,
     "\n" => :enter,
     "\e" => :escape,

--- a/lib/vedeu/output/renderers/all.rb
+++ b/lib/vedeu/output/renderers/all.rb
@@ -103,11 +103,11 @@ module Vedeu
 
     # @return [void]
     def toggle_cursor
-      Vedeu.hide_cursor(Vedeu.focus)
+      Vedeu.trigger(:_hide_cursor_)
 
       yield
 
-      Vedeu.show_cursor(Vedeu.focus)
+      Vedeu.trigger(:_show_cursor_)
     end
 
   end # Renderers

--- a/lib/vedeu/repositories/repository.rb
+++ b/lib/vedeu/repositories/repository.rb
@@ -166,6 +166,7 @@ module Vedeu
 
       private
 
+      # @param model [void] A model instance.
       # @return [String]
       def log_store(model)
         type = registered?(model.name) ? :update : :create

--- a/test/lib/vedeu/buffers/buffer_test.rb
+++ b/test/lib/vedeu/buffers/buffer_test.rb
@@ -149,6 +149,38 @@ module Vedeu
         end
       end
 
+      describe '#size' do
+        subject { instance.size }
+
+        context 'when there is new content on the back buffer' do
+          let(:back) {
+            Vedeu::Views::View.new(value: [Vedeu::Views::Line.new])
+          }
+
+          it { subject.must_equal(1) }
+        end
+
+        context 'when there is existing content on the front buffer' do
+          let(:front) {
+            Vedeu::Views::View.new(value: [Vedeu::Views::Line.new])
+          }
+
+          it { subject.must_equal(1) }
+        end
+
+        context 'when there is content on the previous buffer' do
+          let(:previous) {
+            Vedeu::Views::View.new(value: [Vedeu::Views::Line.new])
+          }
+
+          it { subject.must_equal(1) }
+        end
+
+        context 'when there is no content on any buffer' do
+          it { subject.must_equal(0) }
+        end
+      end
+
     end # Buffer
 
   end # Buffers

--- a/test/lib/vedeu/cursors/cursor_test.rb
+++ b/test/lib/vedeu/cursors/cursor_test.rb
@@ -11,6 +11,8 @@ module Vedeu
     # it { Vedeu.bound?(:_cursor_reset_).must_equal(true) }
     it { Vedeu.bound?(:_cursor_right_).must_equal(true) }
     it { Vedeu.bound?(:_cursor_up_).must_equal(true) }
+    it { Vedeu.bound?(:_cursor_top_).must_equal(true) }
+    it { Vedeu.bound?(:_cursor_bottom_).must_equal(true) }
   end
 
   module Cursors

--- a/test/lib/vedeu/output/renderers/all_test.rb
+++ b/test/lib/vedeu/output/renderers/all_test.rb
@@ -64,8 +64,8 @@ module Vedeu
         Vedeu.stubs(:focus).returns(:vedeu_renderers_render)
         Vedeu::Renderers.reset
         Vedeu::Renderers.renderer(DummyRenderer)
-        Vedeu.stubs(:hide_cursor)
-        Vedeu.stubs(:show_cursor)
+        Vedeu.stubs(:trigger).with(:_hide_cursor_)
+        Vedeu.stubs(:trigger).with(:_show_cursor_)
       end
 
       subject { described.render(output) }
@@ -82,18 +82,23 @@ module Vedeu
               .new(value: Vedeu::EscapeSequences::Esc.hide_cursor)
           }
 
+          it 'hides the cursor before rendering the content to avoid cursor ' \
+             'flicker' do
+            Vedeu.expects(:trigger).with(:_hide_cursor_)
+            subject
+          end
+
+          it 'shows the cursor after rendering the content' do
+            Vedeu.expects(:trigger).with(:_show_cursor_)
+            subject
+          end
+
           it { subject.must_be_instance_of(Vedeu::Models::Escape) }
         end
 
         context 'when there is no content' do
           it { subject.must_be_instance_of(NilClass) }
         end
-      end
-
-      context 'when no interfaces/view have been defined' do
-        before { Vedeu.stubs(:focus).raises(Vedeu::Error::Fatal) }
-
-        it { proc { subject }.must_raise(Vedeu::Error::Fatal) }
       end
     end
 

--- a/test/support/examples/material_colours_app.rb
+++ b/test/support/examples/material_colours_app.rb
@@ -97,7 +97,7 @@ class VedeuMaterialColoursApp
       x(3)
       xn(64)
       y(15)
-      yn(32)
+      yn(34)
     end
     zindex(1)
   end
@@ -107,6 +107,8 @@ class VedeuMaterialColoursApp
     key(:right) { Vedeu.trigger(:_cursor_right_) }
     key(:down)  { Vedeu.trigger(:_cursor_down_)  }
     key(:left)  { Vedeu.trigger(:_cursor_left_)  }
+    key(:home)  { Vedeu.trigger(:_cursor_top_) }
+    key(:end)   { Vedeu.trigger(:_cursor_bottom_) }
 
     key('q')        { Vedeu.trigger(:_exit_) }
     key(:escape)    { Vedeu.trigger(:_mode_switch_) }
@@ -201,6 +203,20 @@ class VedeuMaterialColoursApp
                foreground: '#ffff00', width: 20
         }
         stream { left "Move cursor" }
+      }
+      line {
+        stream {
+          left "home",
+               foreground: '#ffff00', width: 20
+        }
+        stream { left "Move cursor to first line of content." }
+      }
+      line {
+        stream {
+          left "end",
+               foreground: '#ffff00', width: 20
+        }
+        stream { left "Move cursor to last line of content." }
       }
       line {}
       line {


### PR DESCRIPTION
Implement two new events to scroll cursor to top or bottom of the content for a named interface when triggered. Fixes #282.

Also fixes #283 by using `/tmp` instead of `./tmp` for the example applications.