### PR TITLE
Improve rendering/refresh time.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,7 @@ AllCops:
     - '**/Cheffile'
     - '**/Vagabondfile'
   Exclude:
+    - 'benchmarks/**/*'
     - 'examples/**/*'
     - 'test/**/*'
     - 'vendor/**/*'

--- a/.yardopts
+++ b/.yardopts
@@ -5,8 +5,12 @@
 docs/api.md
 docs/borders.md
 docs/buffer.md
+docs/cell.md
+docs/chars.md
+docs/colours_styles.md
 docs/configuration.md
 docs/cursors.md
+docs/debugging.md
 docs/dsl.md
 docs/events.md
 docs/geometry.md
@@ -15,8 +19,11 @@ docs/group.md
 docs/input.md
 docs/interfaces.md
 docs/keymaps.md
+docs/lines.md
 docs/object_graph.md
 docs/output.md
+docs/streams.md
+docs/template.md
 docs/view.md
 docs/events/application.md
 docs/events/document.md

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ have any problems with either of these operating systems.
 **Note**: You may have trouble running Vedeu with Windows installations. (Pull
  requests welcome!)
 
+## Dependencies
+
+Vedeu relies on the following gems, these will be automatically
+ installed when you install Vedeu (as documented below).
+
+- bundler
+- rake
+- ruby-prof
+- thor
+- vedeu_cli
 
 ## Installation
 

--- a/benchmarks/array_vs_range.rb
+++ b/benchmarks/array_vs_range.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+
+# To test the suitability of using a range to determine a valid
+# coordinate instead of the current array method as used in
+# Vedeu::Terminal::Buffer#within_terminal_boundary?
+#
+# vedeu/benchmarks:spike/benchmarking$ ./array_vs_range.rb
+# Calculating -------------------------------------
+#                array   202.400k i/100ms
+#                range   130.641k i/100ms
+# -------------------------------------------------
+#                array      8.171M (± 0.1%) i/s -     40.885M
+#                range      2.471M (± 0.4%) i/s -     12.411M
+#
+# Comparison:
+#                array:  8170584.0 i/s
+#                range:  2470528.5 i/s - 3.31x slower
+#
+
+require "bundler/setup"
+require "benchmark/ips"
+
+YN   = 60
+XN   = 140
+GRID = Array.new(YN) { |y| Array.new(XN) { |x| :"grid_#{y}_#{x}" } }
+Y    = rand(YN)
+X    = rand(XN)
+
+def fast
+  GRID[Y] && GRID[Y][X]
+end
+
+def slow
+  (0..YN).cover?(Y) && (0..XN).cover?(X)
+end
+
+Benchmark.ips do |x|
+  x.report("array") { fast }
+  x.report("range") { slow }
+  x.compare!
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,6 +28,13 @@ methods are used in a variety of ways, sometimes in combination:
     # with other methods
     Vedeu.method_name.other_method
 
+Nearly all of the API methods have associated
+{file:docs/events.md Vedeu Events} which you can bind to or trigger to
+achieve the same effect. It is favoured that you trigger events
+instead of calling API methods as this gives you a bit more visibility
+when debugging, and flexibility when running your application.
+However, how you build your application is up to you! (Of course!)
+
 ## Configuration
 
 See {file:docs/configuration.md}

--- a/docs/colours_styles.md
+++ b/docs/colours_styles.md
@@ -5,4 +5,8 @@
 
 ## Vedeu Background Colours
 
+More coming soon.
+
 ## Vedeu Foreground Colours
+
+More coming soon.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,19 @@
+# @title Debugging Vedeu
+# Debugging Vedeu
+
+If you are encountering a problem whilst running your client
+application, using Vedeu, and have the 'pry' gem installed or
+available, you can drop the following snippet into the offending area,
+and hopefully be dropped into a Pry debuggging session:
+
+    Vedeu::Terminal.cooked_mode!
+    Vedeu::Terminal.open do
+      show_cursor = Vedeu::EscapeSequences::Esc.string('show_cursor')
+      Vedeu::Terminal.output(show_cursor)
+
+      require 'pry'
+      binding.pry
+
+    end
+    Vedeu::Terminal.raw_mode!
+

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,3 +1,4 @@
 # @title Vedeu View Templates
 # Vedeu View Templates
 
+More coming soon.

--- a/examples/284_slow_rendering.rb
+++ b/examples/284_slow_rendering.rb
@@ -1,0 +1,105 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'vedeu'
+
+class EditorApp
+
+  Vedeu.bind(:_initialize_) { Vedeu.trigger(:_refresh_) }
+
+  Vedeu.configure do
+    debug!
+    log '/tmp/284_slow_rendering.log'
+    # renderers Vedeu::Renderers::File.new(filename: '/tmp/284_slow.out')
+    fake!
+  end
+
+  Vedeu.interface :editor_view do
+    border do
+      title 'Editor'
+    end
+    editable!
+    geometry do
+      align(:bottom, :left, Vedeu.width - 21, 10)
+    end
+  end
+
+  Vedeu.interface :members_view do
+    border do
+      title 'Members'
+    end
+    editable!
+    geometry do
+      align(:top, :right, 20, Vedeu.height)
+    end
+  end
+
+  Vedeu.interface :help_view do
+    geometry do
+      height use(:editor_view).height
+      width  use(:editor_view).width
+      x      use(:editor_view).left
+      y      use(:editor_view).south
+    end
+  end
+
+  # When pressing Return/Enter in the editor view, the :_command_
+  # event will be triggered with any typed content you have provided.
+  #
+  # The :_command_ event in turn triggers the :command event. Bind to
+  # :command to retrieve the content entered, and then process
+  # yourself in whatever way appropriate.
+  #
+  #     Vedeu.bind(:command) do |data|
+  #        # ... do something with 'data'
+  #     end
+  #
+  Vedeu.keymap :editor_view do
+    key(:enter) { Vedeu.trigger(:_editor_execute_, :editor_view) }
+    key(:insert) do
+      Vedeu.log(type:    :debug,
+                message: "Commands: #{Vedeu.all_commands.inspect}")
+      Vedeu.log(type:    :debug,
+                message: "Keypresses: #{Vedeu.all_keypresses.inspect}")
+    end
+  end
+
+  Vedeu.keymap '_global_' do
+    key('q') { Vedeu.exit }
+  end
+
+  Vedeu.render do
+    view(:editor_view) do
+    end
+  end
+
+  Vedeu.render do
+    view(:help_view) do
+      lines do
+        line 'Type into the editor dialog above,'
+        line 'and press Return. This will trigger the'
+        line ':command event with the contents of '
+        line 'the view.'
+
+        # @todo Not implemented yet:
+        #
+        # text 'Type into the editor dialog above, and press Return. This will ' \
+        #      'trigger the :_command_ event with the contents of the view.',
+        #      name: :help_view, mode: :wrap
+      end
+    end
+
+    view(:member_view) do
+      lines do
+        line ''
+      end
+    end
+  end
+
+  def self.start(argv = ARGV)
+    Vedeu::Launcher.execute!(argv)
+  end
+
+end # EditorApp
+
+EditorApp.start

--- a/lib/vedeu/borders/dsl.rb
+++ b/lib/vedeu/borders/dsl.rb
@@ -347,6 +347,7 @@ module Vedeu
 
   # @!method border
   #   @see Vedeu::Borders::DSL.border
-  def_delegators Vedeu::Borders::DSL, :border
+  def_delegators Vedeu::Borders::DSL,
+                 :border
 
 end # Vedeu

--- a/lib/vedeu/borders/repository.rb
+++ b/lib/vedeu/borders/repository.rb
@@ -23,7 +23,8 @@ module Vedeu
   #
   # @!method borders
   # @return [Vedeu::Borders::Repository]
-  def_delegators Vedeu::Borders::Repository, :borders
+  def_delegators Vedeu::Borders::Repository,
+                 :borders
 
   # :nocov:
 

--- a/lib/vedeu/buffers/repository.rb
+++ b/lib/vedeu/buffers/repository.rb
@@ -28,6 +28,7 @@ module Vedeu
   #
   # @!method buffers
   # @return [Vedeu::Buffers::Repository]
-  def_delegators Vedeu::Buffers::Repository, :buffers
+  def_delegators Vedeu::Buffers::Repository,
+                 :buffers
 
 end # Vedeu

--- a/lib/vedeu/colours/backgrounds.rb
+++ b/lib/vedeu/colours/backgrounds.rb
@@ -23,6 +23,7 @@ module Vedeu
 
   # @!method background_colours
   # @return [Vedeu::Colours::Backgrounds]
-  def_delegators Vedeu::Colours::Backgrounds, :background_colours
+  def_delegators Vedeu::Colours::Backgrounds,
+                 :background_colours
 
 end # Vedeu

--- a/lib/vedeu/colours/foregrounds.rb
+++ b/lib/vedeu/colours/foregrounds.rb
@@ -23,6 +23,7 @@ module Vedeu
 
   # @!method foreground_colours
   # @return [Vedeu::Colours::Foregrounds]
-  def_delegators Vedeu::Colours::Foregrounds, :foreground_colours
+  def_delegators Vedeu::Colours::Foregrounds,
+                 :foreground_colours
 
 end # Vedeu

--- a/lib/vedeu/configuration/configuration.rb
+++ b/lib/vedeu/configuration/configuration.rb
@@ -353,6 +353,8 @@ module Vedeu
   #   @see Vedeu::Configuration.configure
   # @!method configuration
   #   @see Vedeu::Configuration.configuration
-  def_delegators Vedeu::Configuration, :configure, :configuration
+  def_delegators Vedeu::Configuration,
+                 :configure,
+                 :configuration
 
 end # Vedeu

--- a/lib/vedeu/cursors/cursor.rb
+++ b/lib/vedeu/cursors/cursor.rb
@@ -316,7 +316,9 @@ module Vedeu
   #   @see Vedeu::Toggleable::ClassMethods#show
   # @!method toggle_cursor
   #   @see Vedeu::Toggleable::ClassMethods#toggle
-  def_delegators Vedeu::Cursors::Cursor, :hide_cursor, :show_cursor,
+  def_delegators Vedeu::Cursors::Cursor,
+                 :hide_cursor,
+                 :show_cursor,
                  :toggle_cursor
 
   # :nocov:

--- a/lib/vedeu/cursors/repository.rb
+++ b/lib/vedeu/cursors/repository.rb
@@ -37,7 +37,8 @@ module Vedeu
 
   # @!method cursor
   #   @see Vedeu::Cursors::Repository.cursor
-  def_delegators Vedeu::Cursors::Repository, :cursor
+  def_delegators Vedeu::Cursors::Repository,
+                 :cursor
 
   # Manipulate the repository of cursors.
   #
@@ -46,6 +47,7 @@ module Vedeu
   #
   # @!method cursors
   # @return [Vedeu::Cursors::Repository]
-  def_delegators Vedeu::Cursors::Repository, :cursors
+  def_delegators Vedeu::Cursors::Repository,
+                 :cursors
 
 end # Vedeu

--- a/lib/vedeu/distributed/server.rb
+++ b/lib/vedeu/distributed/server.rb
@@ -246,8 +246,11 @@ module Vedeu
   #   @see Vedeu::Distributed::Server#status
   # @!method drb_stop
   #   @see Vedeu::Distributed::Server#stop
-  def_delegators Vedeu::Distributed::Server, :drb_restart, :drb_start,
-                 :drb_status, :drb_stop
+  def_delegators Vedeu::Distributed::Server,
+                 :drb_restart,
+                 :drb_start,
+                 :drb_status,
+                 :drb_stop
 
   # :nocov:
 

--- a/lib/vedeu/dsl/view.rb
+++ b/lib/vedeu/dsl/view.rb
@@ -253,6 +253,9 @@ module Vedeu
   #   @see Vedeu::DSL::View.renders
   # @!method views
   #   @see Vedeu::DSL::View.views
-  def_delegators Vedeu::DSL::View, :renders, :render, :views
+  def_delegators Vedeu::DSL::View,
+                 :renders,
+                 :render,
+                 :views
 
 end # Vedeu

--- a/lib/vedeu/editor/document.rb
+++ b/lib/vedeu/editor/document.rb
@@ -64,6 +64,7 @@ module Vedeu
           @lines = lines.delete_character(y, x - 1)
 
           left
+
         end
       end
 
@@ -76,6 +77,8 @@ module Vedeu
         up
 
         eol
+
+        refresh
       end
 
       # Returns the document as a string with line breaks if there is
@@ -105,6 +108,8 @@ module Vedeu
         @lines = lines.insert_character(character, y, x)
 
         right
+
+        refresh
       end
 
       # Insert an empty line.
@@ -116,6 +121,8 @@ module Vedeu
         down
 
         bol
+
+        refresh
       end
 
       # Returns the current line from the collection of lines.
@@ -166,9 +173,7 @@ module Vedeu
       def left
         return self if x - 1 < 0
 
-        cursor.left
-
-        refresh
+        cursor.left.refresh
       end
 
       # Move the virtual cursor right.
@@ -177,9 +182,7 @@ module Vedeu
       def right
         return self if x + 1 > line.size
 
-        cursor.right
-
-        refresh
+        cursor.right.refresh
       end
 
       # Move the virtual cursor up.
@@ -188,7 +191,7 @@ module Vedeu
       def up
         return self if y - 1 < 0
 
-        cursor.up
+        cursor.up.refresh
 
         if x > line(y).size
           eol
@@ -205,7 +208,7 @@ module Vedeu
       def down
         return self if y + 1 >= lines.size
 
-        cursor.down
+        cursor.down.refresh
 
         if x > line(y).size
           eol
@@ -220,9 +223,7 @@ module Vedeu
       #
       # @return [Vedeu::Editor::Document]
       def bol
-        cursor.bol
-
-        refresh
+        cursor.bol.refresh
       end
 
       # Move the virtual cursor to the end of the line.
@@ -231,7 +232,7 @@ module Vedeu
       def eol
         cursor.x = line.size
 
-        refresh
+        cursor.refresh
       end
 
       private

--- a/lib/vedeu/editor/repository.rb
+++ b/lib/vedeu/editor/repository.rb
@@ -22,7 +22,8 @@ module Vedeu
   #
   # @!method documents
   # @return [Vedeu::Editor::Repository]
-  def_delegators Vedeu::Editor::Repository, :documents
+  def_delegators Vedeu::Editor::Repository,
+                 :documents
 
   # :nocov:
 

--- a/lib/vedeu/events/aliases.rb
+++ b/lib/vedeu/events/aliases.rb
@@ -108,6 +108,8 @@ module Vedeu
   #   @see Vedeu::Events::Aliases#bind_alias
   # @!method unbind_alias
   #   @see Vedeu::Events::Aliases#unbind_alias
-  def_delegators Vedeu::Events::Aliases, :bind_alias, :unbind_alias
+  def_delegators Vedeu::Events::Aliases,
+                 :bind_alias,
+                 :unbind_alias
 
 end # Vedeu

--- a/lib/vedeu/events/event.rb
+++ b/lib/vedeu/events/event.rb
@@ -126,7 +126,8 @@ module Vedeu
 
         extend Forwardable
 
-        def_delegators Vedeu::Events::Trigger, :trigger
+        def_delegators Vedeu::Events::Trigger,
+                       :trigger
 
       end # Eigenclass
 
@@ -305,6 +306,9 @@ module Vedeu
   #   @see Vedeu::Events::Event.bound?
   # @!method unbind
   #   @see Vedeu::Events::Event.unbind
-  def_delegators Vedeu::Events::Event, :bind, :bound?, :unbind
+  def_delegators Vedeu::Events::Event,
+                 :bind,
+                 :bound?,
+                 :unbind
 
 end # Vedeu

--- a/lib/vedeu/events/repository.rb
+++ b/lib/vedeu/events/repository.rb
@@ -34,6 +34,7 @@ module Vedeu
   #
   # @!method events
   # @return [Vedeu::Events::Repository]
-  def_delegators Vedeu::Events::Repository, :events
+  def_delegators Vedeu::Events::Repository,
+                 :events
 
 end # Vedeu

--- a/lib/vedeu/events/trigger.rb
+++ b/lib/vedeu/events/trigger.rb
@@ -83,6 +83,7 @@ module Vedeu
 
   # @!method trigger
   #   @see Vedeu::Events::Trigger.trigger
-  def_delegators Vedeu::Events::Trigger, :trigger
+  def_delegators Vedeu::Events::Trigger,
+                 :trigger
 
 end # Vedeu

--- a/lib/vedeu/geometry/dsl.rb
+++ b/lib/vedeu/geometry/dsl.rb
@@ -529,6 +529,7 @@ module Vedeu
 
   # @!method geometry
   #   @see Vedeu::Geometry::DSL.geometry
-  def_delegators Vedeu::Geometry::DSL, :geometry
+  def_delegators Vedeu::Geometry::DSL,
+                 :geometry
 
 end # Vedeu

--- a/lib/vedeu/geometry/repository.rb
+++ b/lib/vedeu/geometry/repository.rb
@@ -23,7 +23,8 @@ module Vedeu
   #
   # @!method geometries
   # @return [Vedeu::Geometry::Repository]
-  def_delegators Vedeu::Geometry::Repository, :geometries
+  def_delegators Vedeu::Geometry::Repository,
+                 :geometries
 
   # :nocov:
 

--- a/lib/vedeu/groups/clear.rb
+++ b/lib/vedeu/groups/clear.rb
@@ -56,7 +56,8 @@ module Vedeu
 
   # @!method clear_by_group
   #   @see Vedeu::Groups::Clear.render
-  def_delegators Vedeu::Groups::Clear, :clear_by_group
+  def_delegators Vedeu::Groups::Clear,
+                 :clear_by_group
 
   # :nocov:
 

--- a/lib/vedeu/groups/dsl.rb
+++ b/lib/vedeu/groups/dsl.rb
@@ -94,6 +94,7 @@ module Vedeu
 
   # @!method group
   #   @see Vedeu::Groups::DSL.group
-  def_delegators Vedeu::Groups::DSL, :group
+  def_delegators Vedeu::Groups::DSL,
+                 :group
 
 end # Vedeu

--- a/lib/vedeu/groups/group.rb
+++ b/lib/vedeu/groups/group.rb
@@ -177,7 +177,10 @@ module Vedeu
   #   @see Vedeu::Toggleable::ClassMethods#show
   # @!method toggle_group
   #   @see Vedeu::Toggleable::ClassMethods#toggle
-  def_delegators Vedeu::Groups::Group, :hide_group, :show_group, :toggle_group
+  def_delegators Vedeu::Groups::Group,
+                 :hide_group,
+                 :show_group,
+                 :toggle_group
 
   # :nocov:
 

--- a/lib/vedeu/groups/repository.rb
+++ b/lib/vedeu/groups/repository.rb
@@ -28,6 +28,7 @@ module Vedeu
   #
   # @!method groups
   # @return [Vedeu::Groups::Repository]
-  def_delegators Vedeu::Groups::Repository, :groups
+  def_delegators Vedeu::Groups::Repository,
+                 :groups
 
 end # Vedeu

--- a/lib/vedeu/input/dsl.rb
+++ b/lib/vedeu/input/dsl.rb
@@ -116,6 +116,7 @@ module Vedeu
 
   # @!method keymap
   #   @see Vedeu::Input::DSL.keymap
-  def_delegators Vedeu::Input::DSL, :keymap
+  def_delegators Vedeu::Input::DSL,
+                 :keymap
 
 end # Vedeu

--- a/lib/vedeu/input/keymaps.rb
+++ b/lib/vedeu/input/keymaps.rb
@@ -21,6 +21,7 @@ module Vedeu
   #
   # @!method keymaps
   # @return [Vedeu::Input::Keymaps]
-  def_delegators Vedeu::Input::Keymaps, :keymaps
+  def_delegators Vedeu::Input::Keymaps,
+                 :keymaps
 
 end # Vedeu

--- a/lib/vedeu/input/mapper.rb
+++ b/lib/vedeu/input/mapper.rb
@@ -150,7 +150,8 @@ module Vedeu
 
   # @!method keypress
   #   @see Vedeu::Input::Mapper.keypress
-  def_delegators Vedeu::Input::Mapper, :keypress
+  def_delegators Vedeu::Input::Mapper,
+                 :keypress
 
   # :nocov:
 

--- a/lib/vedeu/interfaces/dsl.rb
+++ b/lib/vedeu/interfaces/dsl.rb
@@ -374,6 +374,7 @@ module Vedeu
 
   # @!method interface
   #   @see Vedeu::Interfaces::DSL.interface
-  def_delegators Vedeu::Interfaces::DSL, :interface
+  def_delegators Vedeu::Interfaces::DSL,
+                 :interface
 
 end # Vedeu

--- a/lib/vedeu/interfaces/interface.rb
+++ b/lib/vedeu/interfaces/interface.rb
@@ -137,7 +137,9 @@ module Vedeu
   #   @see Vedeu::Toggleable::ClassMethods#show
   # @!method toggle_interface
   #   @see Vedeu::Toggleable::ClassMethods#toggle
-  def_delegators Vedeu::Interfaces::Interface, :hide_interface, :show_interface,
+  def_delegators Vedeu::Interfaces::Interface,
+                 :hide_interface,
+                 :show_interface,
                  :toggle_interface
 
   # :nocov:

--- a/lib/vedeu/interfaces/repository.rb
+++ b/lib/vedeu/interfaces/repository.rb
@@ -39,6 +39,7 @@ module Vedeu
   #
   # @!method interfaces
   # @return [Vedeu::Interfaces::Repository]
-  def_delegators Vedeu::Interfaces::Repository, :interfaces
+  def_delegators Vedeu::Interfaces::Repository,
+                 :interfaces
 
 end # Vedeu

--- a/lib/vedeu/logging/all.rb
+++ b/lib/vedeu/logging/all.rb
@@ -12,5 +12,6 @@ end # Vedeu
 require 'vedeu/logging/lockless_log_device'
 require 'vedeu/logging/mono_logger'
 require 'vedeu/logging/log'
+require 'vedeu/logging/ips'
 require 'vedeu/logging/debug'
 require 'vedeu/logging/timer'

--- a/lib/vedeu/logging/debug.rb
+++ b/lib/vedeu/logging/debug.rb
@@ -95,6 +95,7 @@ module Vedeu
   #
   # @!method profile
   # @return [Vedeu::Logging::Debug]
-  def_delegators Vedeu::Logging::Debug, :profile
+  def_delegators Vedeu::Logging::Debug,
+                 :profile
 
 end # Vedeu

--- a/lib/vedeu/logging/ips.rb
+++ b/lib/vedeu/logging/ips.rb
@@ -1,0 +1,64 @@
+require 'benchmark/ips'
+
+module Benchmark
+  module IPS
+    class Report
+      class Entry
+        def display
+          Vedeu.log(type: :debug, message: to_s)
+        end
+      end
+    end
+  end
+end
+
+module Vedeu
+
+  module Logging
+
+    module Debug
+
+      class IPS
+
+        attr_accessor :samples
+        attr_accessor :benchmark
+
+        def initialize(&block)
+          @old_stdout = $stdout
+          $stdout     = StringIO.new
+          @samples    = {}
+          @benchmark  = Benchmark::IPS::Job.new
+          @count      = 0
+        end
+
+        def add_item(label = '', &blk)
+          samples[label] = blk
+          @count += 1
+
+          benchmark.item(label, &blk)
+        end
+
+        def execute!
+          benchmark.compare!
+          benchmark.run_warmup
+          benchmark.run
+
+          $stdout.sync = true
+          benchmark.run_comparison
+          benchmark.full_report
+
+          Vedeu.log(type: :debug, message: "IPS:\n#{$stdout.string}")
+          $stdout = @old_stdout
+
+          key = samples.keys.sample
+          Vedeu.log(type: :debug, message: "Running: #{key}")
+          samples[key].call
+        end
+
+      end # IPS
+
+    end # Debug
+
+  end # Logging
+
+end # Vedeu

--- a/lib/vedeu/logging/ips.rb
+++ b/lib/vedeu/logging/ips.rb
@@ -1,17 +1,5 @@
 require 'benchmark/ips'
 
-module Benchmark
-  module IPS
-    class Report
-      class Entry
-        def display
-          Vedeu.log(type: :debug, message: to_s)
-        end
-      end
-    end
-  end
-end
-
 module Vedeu
 
   module Logging

--- a/lib/vedeu/logging/ips.rb
+++ b/lib/vedeu/logging/ips.rb
@@ -11,7 +11,7 @@ module Vedeu
         attr_accessor :samples
         attr_accessor :benchmark
 
-        def initialize(&block)
+        def initialize
           @old_stdout = $stdout
           $stdout     = StringIO.new
           @samples    = {}
@@ -38,9 +38,14 @@ module Vedeu
           Vedeu.log(type: :debug, message: "IPS:\n#{$stdout.string}")
           $stdout = @old_stdout
 
-          key = samples.keys.sample
           Vedeu.log(type: :debug, message: "Running: #{key}")
           samples[key].call
+        end
+
+        private
+
+        def key
+          @key ||= samples.keys.sample
         end
 
       end # IPS

--- a/lib/vedeu/logging/log.rb
+++ b/lib/vedeu/logging/log.rb
@@ -191,7 +191,10 @@ module Vedeu
   #   @see Vedeu::Logging::Log.log_stdout
   # @!method log_stderr
   #   @see Vedeu::Logging::Log.log_stderr
-  def_delegators Vedeu::Logging::Log, :log, :log_stdout, :log_stderr
+  def_delegators Vedeu::Logging::Log,
+                 :log,
+                 :log_stdout,
+                 :log_stderr
 
   # :nocov:
 

--- a/lib/vedeu/logging/timer.rb
+++ b/lib/vedeu/logging/timer.rb
@@ -91,6 +91,7 @@ module Vedeu
   #
   # @!method timer
   #   @see Vedeu::Logging::Timer.timer
-  def_delegators Vedeu::Logging::Timer, :timer
+  def_delegators Vedeu::Logging::Timer,
+                 :timer
 
 end # Vedeu

--- a/lib/vedeu/menus/menu.rb
+++ b/lib/vedeu/menus/menu.rb
@@ -201,6 +201,7 @@ module Vedeu
 
   # @!method menu
   #   @see Vedeu::Menus::DSL.menu
-  def_delegators Vedeu::Menus::DSL, :menu
+  def_delegators Vedeu::Menus::DSL,
+                 :menu
 
 end # Vedeu

--- a/lib/vedeu/menus/repository.rb
+++ b/lib/vedeu/menus/repository.rb
@@ -22,7 +22,8 @@ module Vedeu
   #
   # @!method menus
   # @return [Vedeu::Menus::Repository]
-  def_delegators Vedeu::Menus::Repository, :menus
+  def_delegators Vedeu::Menus::Repository,
+                 :menus
 
   # :nocov:
 

--- a/lib/vedeu/models/focus.rb
+++ b/lib/vedeu/models/focus.rb
@@ -262,8 +262,12 @@ module Vedeu
   #   @see Vedeu::Models::Focus#focus_next
   # @!method focus_previous
   #   @see Vedeu::Models::Focus#focus_previous
-  def_delegators Vedeu::Models::Focus, :focus, :focus_by_name, :focussed?,
-                 :focus_next, :focus_previous
+  def_delegators Vedeu::Models::Focus,
+                 :focus,
+                 :focus_by_name,
+                 :focussed?,
+                 :focus_next,
+                 :focus_previous
 
   # :nocov:
 

--- a/lib/vedeu/output/clear/interface.rb
+++ b/lib/vedeu/output/clear/interface.rb
@@ -37,7 +37,7 @@ module Vedeu
         def clear_content_by_name(name = Vedeu.focus)
           name || Vedeu.focus
 
-          new(name, content_only: true).render
+          new(name, content_only: true, direct: true).render
         end
 
       end # Eigenclass
@@ -49,6 +49,11 @@ module Vedeu
       # @param options [Hash]
       # @option options content_only [Boolean] Only clear the content
       #   not the border as well. Defaults to false.
+      # @option options direct [Boolean] Write the content directly
+      #   to the terminal using a faster mechanism. The virtual buffer
+      #   will still be updated. This improves the refresh time for
+      #   Vedeu as we will not be building a grid of
+      #   {Vedeu::Views::Char} objects.
       # @return [Vedeu::Clear::Interface]
       def initialize(name, options = {})
         @name    = present?(name) ? name : Vedeu.focus
@@ -57,7 +62,15 @@ module Vedeu
 
       # @return [Array<Array<Vedeu::Views::Char>>]
       def render
-        Vedeu.render_output(output)
+        if direct?
+          Vedeu.direct_write(optimised_output)
+
+          Vedeu::Terminal::Buffer.update(output)
+
+        else
+          Vedeu.render_output(output)
+
+        end
       end
 
       protected
@@ -87,7 +100,13 @@ module Vedeu
       def defaults
         {
           content_only: false,
+          direct:       false,
         }
+      end
+
+      # @return [Boolean]
+      def direct?
+        options[:direct]
       end
 
       # @see Vedeu::Geometry::Repository#by_name
@@ -110,6 +129,27 @@ module Vedeu
       # @return [Hash<Symbol => Boolean>]
       def options
         defaults.merge!(@options)
+      end
+
+      # @return [String]
+      def optimised_output
+        Vedeu.timer("Optimised clearing #{clearing}: '#{name}'".freeze) do
+          output = ''
+
+          @y = y
+          @x = x
+          @colour = colour.to_s
+          @chars  = (' ' * width).freeze
+
+          height.times do |iy|
+            output << Vedeu::Geometry::Position.new(@y + iy, @x).to_s
+            output << @colour
+            output << @chars
+          end
+
+          output << Vedeu::Geometry::Position.new(@y, @x).to_s
+          output
+        end
       end
 
       # For each visible line of the interface, set the foreground and

--- a/lib/vedeu/output/clear/interface.rb
+++ b/lib/vedeu/output/clear/interface.rb
@@ -170,11 +170,13 @@ module Vedeu
 
   # @!method clear_by_name
   #   @see Vedeu::Clear::Interface.render
-  def_delegators Vedeu::Clear::Interface, :clear_by_name
+  def_delegators Vedeu::Clear::Interface,
+                 :clear_by_name
 
   # @!method clear_content_by_name
   #   @see Vedeu::Clear::Interface.clear_content_by_name
-  def_delegators Vedeu::Clear::Interface, :clear_content_by_name
+  def_delegators Vedeu::Clear::Interface,
+                 :clear_content_by_name
 
   # :nocov:
 

--- a/lib/vedeu/output/compressor.rb
+++ b/lib/vedeu/output/compressor.rb
@@ -56,7 +56,7 @@ module Vedeu
 
       # @return [String]
       def compress
-        Vedeu.timer('Compression'.freeze) do
+        Vedeu.timer("Compression for #{content.size} characters".freeze) do
           out = ''
 
           content.each do |cell|

--- a/lib/vedeu/output/output.rb
+++ b/lib/vedeu/output/output.rb
@@ -80,6 +80,7 @@ module Vedeu
   #
   # @!method render_output
   # @return [Array|NilClass]
-  def_delegators Vedeu::Output::Output, :render_output
+  def_delegators Vedeu::Output::Output,
+                 :render_output
 
 end # Vedeu

--- a/lib/vedeu/output/output.rb
+++ b/lib/vedeu/output/output.rb
@@ -9,10 +9,29 @@ module Vedeu
     #
     class Output
 
+      # @param output [Array<Array<Vedeu::Views::Char>>|
+      #   NilClass|Vedeu::Models::Escape]
+      # @return [Array]
+      def self.buffer_write(output)
+        return nil if output.nil?
+
+        new(output).buffer_write
+      end
+
+      # @param output [Array<Array<Vedeu::Views::Char>>|
+      #   NilClass|Vedeu::Models::Escape]
+      # @return [Array<String>]
+      def self.direct_write(output)
+        return nil if output.nil?
+
+        new(output).direct_write
+      end
+
       # Writes output to the defined renderers.
       #
+      # @param output [Array<Array<Vedeu::Views::Char>>|
+      #   NilClass|Vedeu::Models::Escape]
       # @return [Array|NilClass|String]
-      # @see #initialize
       def self.render_output(output)
         return nil if output.nil?
 
@@ -21,10 +40,21 @@ module Vedeu
 
       # Return a new instance of Vedeu::Output::Output.
       #
-      # @param output [Array<Array<Vedeu::Views::Char>>]
+      # @param output [Array<Array<Vedeu::Views::Char>>|
+      #   NilClass|Vedeu::Models::Escape]
       # @return [Vedeu::Output::Output]
       def initialize(output)
         @output = output
+      end
+
+      # @return [Array]
+      def buffer_write
+        buffer_write!
+      end
+
+      # @return [Array<String>]
+      def direct_write
+        direct_write!
       end
 
       # Send the view to the renderers. If the output is a
@@ -81,6 +111,8 @@ module Vedeu
   # @!method render_output
   # @return [Array|NilClass]
   def_delegators Vedeu::Output::Output,
-                 :render_output
+                 :render_output,
+                 :buffer_write,
+                 :direct_write
 
 end # Vedeu

--- a/lib/vedeu/output/renderers/all.rb
+++ b/lib/vedeu/output/renderers/all.rb
@@ -120,7 +120,9 @@ module Vedeu
   #   @see Vedeu::Renderers#renderer
   # @!method renderers
   #   @see Vedeu::Renderers#renderers
-  def_delegators Vedeu::Renderers, :renderer, :renderers
+  def_delegators Vedeu::Renderers,
+                 :renderer,
+                 :renderers
 
 end # Vedeu
 

--- a/lib/vedeu/runtime/application.rb
+++ b/lib/vedeu/runtime/application.rb
@@ -135,7 +135,8 @@ module Vedeu
 
   # @!method exit
   #   @see Vedeu::Runtime::Application.stop
-  def_delegators Vedeu::Runtime::Application, :exit
+  def_delegators Vedeu::Runtime::Application,
+                 :exit
 
   # :nocov:
 

--- a/lib/vedeu/runtime/flags.rb
+++ b/lib/vedeu/runtime/flags.rb
@@ -63,7 +63,9 @@ module Vedeu
   # @!method ready?
   # @!method ready!
   # @return [Boolean]
-  def_delegators Vedeu::Runtime::Flags, :ready?, :ready!
+  def_delegators Vedeu::Runtime::Flags,
+                 :ready?,
+                 :ready!
 
   # :nocov:
 

--- a/lib/vedeu/runtime/main_loop.rb
+++ b/lib/vedeu/runtime/main_loop.rb
@@ -24,9 +24,9 @@ module Vedeu
 
           Vedeu.trigger(:_refresh_cursor_, Vedeu.focus)
 
-          while @loop
-            Vedeu.refresh
+          Vedeu.trigger(:_refresh_)
 
+          while @loop
             yield
 
             safe_exit_point!

--- a/lib/vedeu/runtime/router.rb
+++ b/lib/vedeu/runtime/router.rb
@@ -191,7 +191,8 @@ module Vedeu
 
   # @!method goto
   #   @see Vedeu::Runtime::Router#goto
-  def_delegators Vedeu::Runtime::Router, :goto
+  def_delegators Vedeu::Runtime::Router,
+                 :goto
 
   # :nocov:
 

--- a/lib/vedeu/terminal/buffer.rb
+++ b/lib/vedeu/terminal/buffer.rb
@@ -84,18 +84,26 @@ module Vedeu
         end
       end
 
-      # Write a collection of cells to the virtual terminal.
+      # Write a collection of cells to the virtual terminal, will
+      # then send written content to be rendered by a renderer.
       #
       # @param value [Array<Array<Vedeu::Views::Char>>]
       # @return [Array<Array<Vedeu::Views::Char>>]
       def write(value)
-        values = Array(value).flatten
-
-        values.each do |v|
-          buffer[v.position.y][v.position.x] = v if valid_position?(v)
-        end
+        update_buffer(value)
 
         render
+
+        self
+      end
+
+      # Write a collection of cells to the virtual terminal, but do
+      # not send to a renderer.
+      #
+      # @param value [Array<Array<Vedeu::Views::Char>>]
+      # @return [Array<Array<Vedeu::Views::Char>>]
+      def update(value)
+        update_buffer(value)
 
         self
       end
@@ -118,6 +126,16 @@ module Vedeu
       def position?(value)
         value.respond_to?(:position) &&
           value.position.is_a?(Vedeu::Geometry::Position)
+      end
+
+      # @param value [Array<Array<Vedeu::Views::Char>>]
+      # @return [Array<Array<Vedeu::Views::Char>>]
+      def update_buffer(value)
+        values = Array(value).flatten
+
+        values.each do |v|
+          buffer[v.position.y][v.position.x] = v if valid_position?(v)
+        end
       end
 
       # Returns a boolean indicating the value has a position

--- a/lib/vedeu/terminal/buffer.rb
+++ b/lib/vedeu/terminal/buffer.rb
@@ -144,8 +144,9 @@ module Vedeu
 
   # @!method clear
   #   @see Vedeu::Terminal::Buffer#clear
-  def_delegators Vedeu::Terminal::Buffer, :clear
-  def_delegators Vedeu::Terminal::Buffer, :refresh
+  def_delegators Vedeu::Terminal::Buffer,
+                 :clear,
+                 :refresh
 
   # :nocov:
 

--- a/lib/vedeu/terminal/terminal.rb
+++ b/lib/vedeu/terminal/terminal.rb
@@ -222,7 +222,10 @@ module Vedeu
   #   @see Vedeu::Terminal#resize
   # @!method width
   #   @see Vedeu::Terminal#width
-  def_delegators Vedeu::Terminal, :height, :resize, :width
+  def_delegators Vedeu::Terminal,
+                 :height,
+                 :resize,
+                 :width
 
   # :nocov:
 

--- a/test/lib/vedeu/editor/document_test.rb
+++ b/test/lib/vedeu/editor/document_test.rb
@@ -35,6 +35,7 @@ module Vedeu
         Vedeu.geometries.stubs(:by_name).with(_name).returns(geometry)
         Vedeu.interfaces.stubs(:by_name).with(_name).returns(interface)
 
+        Vedeu.stubs(:direct_write)
         Vedeu.stubs(:render_output)
       }
 

--- a/test/lib/vedeu/output/clear/interface_test.rb
+++ b/test/lib/vedeu/output/clear/interface_test.rb
@@ -16,6 +16,7 @@ module Vedeu
       let(:options)   {
         {
           content_only: false,
+          direct:       false,
         }
       }
       let(:_name)     { 'Vedeu::Clear::Interface' }

--- a/test/lib/vedeu/output/output_test.rb
+++ b/test/lib/vedeu/output/output_test.rb
@@ -16,6 +16,42 @@ module Vedeu
         it { instance.instance_variable_get('@output').must_equal(output) }
       end
 
+      describe '.buffer_write' do
+        subject { described.buffer_write(output) }
+
+        context 'when the output is empty' do
+          it { subject.must_be_instance_of(NilClass) }
+        end
+
+        context 'when the output is not empty' do
+          let(:output) { Vedeu::Models::Page.new }
+
+          it {
+            Vedeu::Terminal::Buffer.expects(:write).with(output)
+            subject
+          }
+        end
+      end
+
+      describe '.direct_write' do
+        subject { described.direct_write(output) }
+
+        context 'when the output is empty' do
+          it { subject.must_be_instance_of(NilClass) }
+        end
+
+        context 'when the output is not empty' do
+          let(:output) {
+            Vedeu::Models::Escape.new(value: "\e[?25h", position: [1, 1])
+          }
+
+          it {
+            Vedeu::Terminal.expects(:output).with(output.to_s)
+            subject
+          }
+        end
+      end
+
       describe '.render_output' do
         subject { described.render_output(output) }
 
@@ -30,7 +66,7 @@ module Vedeu
             }
 
             it {
-              Vedeu::Terminal.expects(:output)
+              Vedeu::Terminal.expects(:output).with(output.to_s)
               subject
             }
           end
@@ -44,6 +80,14 @@ module Vedeu
             }
           end
         end
+      end
+
+      describe '#buffer_write' do
+        it { instance.must_respond_to(:buffer_write) }
+      end
+
+      describe '#direct_write' do
+        it { instance.must_respond_to(:direct_write) }
       end
 
       describe '#render_output' do

--- a/test/lib/vedeu/terminal/buffer_test.rb
+++ b/test/lib/vedeu/terminal/buffer_test.rb
@@ -49,6 +49,7 @@ module Vedeu
         end
 
         context 'when Vedeu is not ready' do
+          # @todo Add more tests.
         end
       end
 
@@ -86,6 +87,16 @@ module Vedeu
         let(:_value) {}
 
         subject { described.write(_value) }
+
+        # @todo Add more tests.
+      end
+
+      describe '#update' do
+        let(:_value) {}
+
+        subject { described.update(_value) }
+
+        # @todo Add more tests.
       end
 
     end # Buffer

--- a/test/lib/vedeu_test.rb
+++ b/test/lib/vedeu_test.rb
@@ -13,6 +13,7 @@ describe Vedeu do
   it { Vedeu.must_respond_to(:borders) }
   it { Vedeu.must_respond_to(:bound?) }
   it { Vedeu.must_respond_to(:buffers) }
+  it { Vedeu.must_respond_to(:buffer_write) }
   it { Vedeu.must_respond_to(:clear) }
   it { Vedeu.must_respond_to(:clear_by_group) }
   it { Vedeu.must_respond_to(:clear_by_name) }
@@ -21,6 +22,7 @@ describe Vedeu do
   it { Vedeu.must_respond_to(:configure) }
   it { Vedeu.must_respond_to(:cursor) }
   it { Vedeu.must_respond_to(:cursors) }
+  it { Vedeu.must_respond_to(:direct_write) }
   it { Vedeu.must_respond_to(:documents) }
   it { Vedeu.must_respond_to(:drb_restart) }
   it { Vedeu.must_respond_to(:drb_start) }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -123,3 +123,24 @@ def test_configuration
 end
 
 test_configuration
+
+# require "benchmark/ips"
+
+# def fast
+# end
+
+# def slow
+# end
+
+# Benchmark.ips do |x|
+#   x.report("describe") { fast }
+#   x.report("describe") { slow }
+#   x.compare!
+# end
+
+# ips = Vedeu::Logging::Debug::IPS.new
+# ips.add_item('original') do
+# end
+# ips.add_item('newimproved') do
+# end
+# ips.execute!

--- a/vedeu.gemspec
+++ b/vedeu.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.add_development_dependency 'benchmark-ips',      '2.3.0'
   spec.add_development_dependency 'guard',              '2.13.0'
   spec.add_development_dependency 'guard-minitest',     '2.4.4'
   spec.add_development_dependency 'guard-rubocop',      '1.2.0'


### PR DESCRIPTION
Using an alternate mechanism to clear the content from a view, the rendering and refresh time has improved. From the 'examples/284_slow_rendering.rb' example:

**Old:**
Startup: ~350ms
Keypress: ~106ms

**New:**
Startup: ~245ms (~1.4 times faster)
Keypress: ~27ms (~3.9 times faster) 
