### PR TITLE
Improve logging.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if ENV['RUBOCOP'].to_i == 1
   guard :rubocop do
     watch(/.+\.rb$/)

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'yard'

--- a/bin/vedeu
+++ b/bin/vedeu
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+# frozen_string_literal: true
+
 require 'rake'
 bundler_message = 'Bundler is required. Please install bundler with ' \
                   "'gem install bundler'"

--- a/bin/vedeu_drb_client
+++ b/bin/vedeu_drb_client
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+# frozen_string_literal: true
+
 lib_dir = File.dirname(__FILE__) + '/../lib'
 $LOAD_PATH.unshift(lib_dir) unless $LOAD_PATH.include?(lib_dir)
 

--- a/bin/vedeu_drb_server
+++ b/bin/vedeu_drb_server
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+# frozen_string_literal: true
+
 lib_dir = '/Users/gavinlaking/Source/vedeu/lib/vedeu/distributed/../../../lib'
 $LOAD_PATH.unshift(lib_dir) unless $LOAD_PATH.include?(lib_dir)
 

--- a/bin/vedeu_test
+++ b/bin/vedeu_test
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+# frozen_string_literal: true
+
 lib_dir = File.dirname(__FILE__) + '/../lib'
 $LOAD_PATH.unshift(lib_dir) unless $LOAD_PATH.include?(lib_dir)
 

--- a/docs/configuration/background.md
+++ b/docs/configuration/background.md
@@ -1,0 +1,9 @@
+Configure the background colour for the client application.
+
+    # Set:
+    Vedeu.configure do
+      background '#330000'
+    end
+
+    # Get:
+    Vedeu.config.background

--- a/docs/configuration/foreground.md
+++ b/docs/configuration/foreground.md
@@ -1,0 +1,9 @@
+Configure the foreground colour for the client application.
+
+    # Set:
+    Vedeu.configure do
+      foreground '#00aa33'
+    end
+
+    # Get:
+    Vedeu.config.foreground

--- a/lib/vedeu/application/all.rb
+++ b/lib/vedeu/application/all.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'vedeu/application/controller'
 require 'vedeu/application/helper'
 require 'vedeu/application/view'

--- a/lib/vedeu/common.rb
+++ b/lib/vedeu/common.rb
@@ -43,6 +43,17 @@ module Vedeu
       value.is_a?(TrueClass) || value.is_a?(FalseClass)
     end
 
+    # Returns a boolean indicating the value is empty.
+    #
+    # @param value [void]
+    # @return [Boolean]
+    def empty_value?(value)
+      return true if value.respond_to?(:empty?) && value.empty?
+      return true if value.nil?
+
+      false
+    end
+
     # Returns a boolean indicating whether the value is an escape
     # sequence object (e.g. {Vedeu::Cells::Escape}.)
     #

--- a/lib/vedeu/common.rb
+++ b/lib/vedeu/common.rb
@@ -8,13 +8,14 @@ module Vedeu
   #
   module Common
 
-    # Returns a boolean indicating whether a variable is nil or empty.
+    # Returns a boolean indicating whether a variable is nil, false or
+    # empty.
     #
     # @param variable [String|Symbol|Array|Fixnum] The variable to
     #   check.
     # @return [Boolean]
     def absent?(variable)
-      !present?(variable)
+      variable == false || !present?(variable)
     end
 
     # Returns a boolean indicating whether the value is an Array.
@@ -120,8 +121,8 @@ module Vedeu
     # @return [Boolean]
     def present?(variable)
       return true  if numeric?(variable)
-      return false if variable.nil?
-      return false if variable.respond_to?(:empty?) && variable.empty?
+      return false if variable.nil? || variable == false
+      return false if empty_value?(variable)#.respond_to?(:empty?) && variable.empty?
 
       true
     end

--- a/lib/vedeu/common.rb
+++ b/lib/vedeu/common.rb
@@ -25,7 +25,7 @@ module Vedeu
       value.is_a?(Array)
     end
 
-    # Returns a boolean indicating the value was a boolean.
+    # Returns a boolean indicating the value is a boolean.
     #
     # @param value [void]
     # @return [Boolean]

--- a/lib/vedeu/common.rb
+++ b/lib/vedeu/common.rb
@@ -122,7 +122,7 @@ module Vedeu
     def present?(variable)
       return true  if numeric?(variable)
       return false if variable.nil? || variable == false
-      return false if empty_value?(variable)#.respond_to?(:empty?) && variable.empty?
+      return false if empty_value?(variable)
 
       true
     end

--- a/lib/vedeu/configuration/all.rb
+++ b/lib/vedeu/configuration/all.rb
@@ -4,21 +4,9 @@ module Vedeu
 
   # Namespace for configuration classes.
   #
+  # @api public
+  #
   module Config
-
-    module_function
-
-    # Custom log for configuration.
-    #
-    # @param from [String] Which configuration set the options.
-    # @param options [Hash<Symbol => void>] The configuration options set.
-    # @return [Hash<Symbol => void>] The options param.
-    def log(from, options)
-      options.each do |option, value|
-        Vedeu.log(type:    :config,
-                  message: "#{from} #{option}: #{value}")
-      end
-    end
 
   end # Config
 

--- a/lib/vedeu/configuration/api.rb
+++ b/lib/vedeu/configuration/api.rb
@@ -493,13 +493,7 @@ module Vedeu
       end
       alias width= width
 
-      # Sets the background of the terminal.
-      #
-      #   Vedeu.configure do
-      #     background '#ff0000'
-      #     # ...
-      #   end
-      #
+      # {include:file:docs/configuration/background.md}
       # @param value [String]
       # @return [Vedeu::Colours::Background]
       def background(value = nil)
@@ -508,13 +502,7 @@ module Vedeu
         options[:background] = value
       end
 
-      # Sets the foreground of the terminal.
-      #
-      #   Vedeu.configure do
-      #     foreground '#ffff00'
-      #     # ...
-      #   end
-      #
+      # {include:file:docs/configuration/foreground.md}
       # @param value [String]
       # @return [Vedeu::Colours::Foreground]
       def foreground(value = nil)

--- a/lib/vedeu/configuration/api.rb
+++ b/lib/vedeu/configuration/api.rb
@@ -263,15 +263,15 @@ module Vedeu
       # @param filename_or_false [FalseClass|String]
       # @return [NilClass|String]
       def log(filename_or_false = false)
-        if filename_or_false.nil? ||
-           filename_or_false == false ||
-           empty_value?(filename_or_false)
-          options[:log] = nil
+        options[:log] = if filename_or_false.nil? ||
+                           filename_or_false == false ||
+                           empty_value?(filename_or_false)
+                          nil
 
-        else
-          options[:log] = filename_or_false
+                        else
+                          filename_or_false
 
-        end
+                        end
       end
 
       # Log specific message types except those given. A complete list

--- a/lib/vedeu/configuration/configuration.rb
+++ b/lib/vedeu/configuration/configuration.rb
@@ -18,9 +18,7 @@ module Vedeu
 
       include Vedeu::Common
 
-      # Return the configured background colour for the client
-      # application.
-      #
+      # {include:file:docs/configuration/background.md}
       # @return [String|Symbol]
       def background
         instance.options[:background]
@@ -121,9 +119,7 @@ module Vedeu
         instance.options[:drb_width]
       end
 
-      # Return the configured foreground colour for the client
-      # application.
-      #
+      # {include:file:docs/configuration/foreground.md}
       # @return [String|Symbol]
       def foreground
         instance.options[:foreground]

--- a/lib/vedeu/configuration/configuration.rb
+++ b/lib/vedeu/configuration/configuration.rb
@@ -171,7 +171,9 @@ module Vedeu
       #
       # @return [Boolean]
       def log?
-        present?(log)
+        return false if log == false || log.nil?
+
+        true
       end
 
       # @return [Array<Symbol>]
@@ -368,6 +370,8 @@ module Vedeu
 
     end # Eigenclass
 
+    include Vedeu::Common
+
     # @!attribute [r] options
     # @return [Hash<Symbol => void>]
     attr_reader :options
@@ -387,7 +391,7 @@ module Vedeu
     def configure(opts = {}, &block)
       @options.merge!(opts)
 
-      @options.merge!(Config::API.configure(&block)) if block_given?
+      @options.merge!(Config::API.configure(defaults, &block)) if block_given?
 
       Vedeu::Configuration
     end
@@ -417,7 +421,7 @@ module Vedeu
         foreground:    :default,
         height:        nil,
         interactive:   true,
-        log:           nil,
+        log:           '/tmp/vedeu_bootstrap.log',
         log_except:    [],
         log_only:      [],
         mouse:         true,

--- a/lib/vedeu/logging/log.rb
+++ b/lib/vedeu/logging/log.rb
@@ -23,16 +23,13 @@ module Vedeu
         #             message: 'A useful debugging message: Error!')
         #
         # @macro vedeu_logging_log_param_message
-        # @param force [Boolean] When evaluates to true will attempt
-        #   to write to the log file regardless of the Configuration
-        #   setting.
         # @param type [Symbol] Colour code messages in the log file
         #   depending on their source. See
         #   {Vedeu::Configuration.log_types}
         #
         # @return [String]
-        def log(message:, force: false, type: :info)
-          if (Vedeu.config.log? || force) && Vedeu.config.loggable?(type)
+        def log(message:, type: :info)
+          if Vedeu.config.log? && Vedeu.config.loggable?(type)
             output = log_entry(type, message)
             logger.debug(output)
             output

--- a/lib/vedeu/plugins/all.rb
+++ b/lib/vedeu/plugins/all.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require 'vedeu/plugins/plugins'
 require 'vedeu/plugins/plugin'

--- a/lib/vedeu/runtime/launcher.rb
+++ b/lib/vedeu/runtime/launcher.rb
@@ -109,7 +109,7 @@ module Vedeu
     #
     # @return [void]
     def terminate!
-      Vedeu.log(message: 'Exiting gracefully.')
+      Vedeu.log(message: "Exiting gracefully.\n")
 
       $stdin  = STDIN
       $stdout = STDOUT

--- a/lib/vedeu/views/stream.rb
+++ b/lib/vedeu/views/stream.rb
@@ -1,7 +1,7 @@
+# frozen_string_literal: true
+
 require 'vedeu/dsl/all'
 require 'vedeu/cells/all'
-
-# frozen_string_literal: true
 
 module Vedeu
 

--- a/test/lib/vedeu/common_test.rb
+++ b/test/lib/vedeu/common_test.rb
@@ -43,6 +43,12 @@ module Vedeu
         it { subject.must_equal(false) }
       end
 
+      context 'when the variable is false' do
+        let(:_value) { false }
+
+        it { subject.must_equal(true) }
+      end
+
       context 'when the variable is not nil or empty' do
         let(:_value) { 'not empty' }
 
@@ -307,6 +313,12 @@ module Vedeu
         let(:_value) { :some_value }
 
         it { subject.must_equal(true) }
+      end
+
+      context 'when the variable is false' do
+        let(:_value) { false }
+
+        it { subject.must_equal(false) }
       end
 
       context 'when the variable is not nil or empty' do

--- a/test/lib/vedeu/common_test.rb
+++ b/test/lib/vedeu/common_test.rb
@@ -107,6 +107,38 @@ module Vedeu
       end
     end
 
+    describe '#empty_value?' do
+      let(:_value) {}
+
+      subject { instance.empty_value?(_value) }
+
+      context 'when the value does not respond to :empty?' do
+        context 'when the value is nil' do
+          it { subject.must_equal(true) }
+        end
+
+        context 'whent the value is not nil' do
+          let(:_value) { :some_value }
+
+          it { subject.must_equal(false) }
+        end
+      end
+
+      context 'when the value responds to :empty?' do
+        context 'when the value is not empty' do
+          let(:_value) { [:some_value] }
+
+          it { subject.must_equal(false) }
+        end
+
+        context 'when the value is empty' do
+          let(:_value) { [] }
+
+          it { subject.must_equal(true) }
+        end
+      end
+    end
+
     describe '#boolean?' do
       subject { instance.boolean?(_value) }
 

--- a/test/lib/vedeu/configuration/api_test.rb
+++ b/test/lib/vedeu/configuration/api_test.rb
@@ -23,7 +23,8 @@ module Vedeu
     describe API do
 
       let(:described) { Vedeu::Config::API }
-      let(:instance)  { described.new }
+      let(:instance)  { described.new(default) }
+      let(:default)   { {} }
 
       after  { test_configuration }
 

--- a/test/lib/vedeu/configuration/configuration_test.rb
+++ b/test/lib/vedeu/configuration/configuration_test.rb
@@ -65,10 +65,12 @@ module Vedeu
 
     describe '.log' do
       context 'when the log is not configured' do
-        it { described.log.must_equal(nil) }
+        it 'sends messages to the default log' do
+          described.log.must_equal('/tmp/vedeu_bootstrap.log')
+        end
       end
 
-      context 'when the log is configured' do
+      context 'when the log is configured with a filename' do
         before do
           Vedeu.configure do
             log '/tmp/vedeu.log'
@@ -77,21 +79,31 @@ module Vedeu
 
         it { described.log.must_equal('/tmp/vedeu.log') }
       end
-    end
 
-    describe '.log?' do
-      context 'when the log is not configured' do
-        it { described.log?.must_equal(false) }
-      end
-
-      context 'when the log is configured' do
+      context 'when the log is configured with false' do
         before do
           Vedeu.configure do
-            log '/tmp/vedeu.log'
+            log false
           end
         end
 
+        it { described.log.must_equal(nil) }
+      end
+    end
+
+    describe '.log?' do
+      context 'when the log is enabled' do
         it { described.log?.must_equal(true) }
+      end
+
+      context 'when the log is disabled' do
+        before do
+          Vedeu.configure do
+            log false
+          end
+        end
+
+        it { described.log?.must_equal(false) }
       end
     end
 

--- a/test/lib/vedeu/logging/log_test.rb
+++ b/test/lib/vedeu/logging/log_test.rb
@@ -14,14 +14,15 @@ module Vedeu
 
       let(:described) { Vedeu::Logging::Log }
       let(:_message)  { 'Some message...' }
-      let(:force)     { false }
       let(:type)      { :info }
 
       describe '.log' do
-        subject { described.log(message: _message, force: force, type: type) }
+        before { Vedeu.config.stubs(:log?).returns(enabled) }
 
-        context 'when :force is true' do
-          let(:force) { true }
+        subject { described.log(message: _message, type: type) }
+
+        context 'when the log is enabled' do
+          let(:enabled)  { true }
           let(:expected) {
             "\e[97m[info]     \e[39m\e[37mSome message...\e[39m"
           }
@@ -29,8 +30,8 @@ module Vedeu
           it { subject.must_equal(expected) }
         end
 
-        context 'when :force is false' do
-          let(:force) { false }
+        context 'when the log is disabled' do
+          let(:enabled)  { false }
 
           it { subject.must_equal(nil) }
         end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -118,14 +118,12 @@ def test_configuration
 
   Vedeu.configure do
     colour_mode 16_777_216
-    # adds ~40ms to test run speed
-    # debug!
-    # profile!
 
-    # if debug! above is commented out, then only
-    # `Vedeu.log(type: <any type>, message: '...', force: true)`
-    # will be logged, otherwise every `Vedeu.log` will be logged.
+    # debug! # adds ~40ms to test run speed
+
     # log '/tmp/vedeu_test_helper.log'
+
+    # profile!
   end
 
   # Vedeu::Repositories.reset!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -122,6 +122,7 @@ def test_configuration
     # debug! # adds ~40ms to test run speed
 
     # log '/tmp/vedeu_test_helper.log'
+    log false
 
     # profile!
   end

--- a/vedeu.gemspec
+++ b/vedeu.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
@@ -26,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest',           '5.8.4'
   spec.add_development_dependency 'minitest-reporters', '1.1.7'
   spec.add_development_dependency 'mocha',              '1.1.0'
-  spec.add_development_dependency 'rubocop',            '0.37.0'
+  spec.add_development_dependency 'rubocop',            '0.37.1'
   spec.add_development_dependency 'simplecov',          '0.11.2'
   spec.add_development_dependency 'simplecov-console',  '0.3.0'
   spec.add_development_dependency 'yard',               '0.8.7.6'


### PR DESCRIPTION
Significantly improve logging; …
- Remove the useless `:force` option from `Logging::Log`.
- Improve the configuration of a log file for the `Configuration API`;
  - Vedeu will always log to `/tmp/vedeu_bootstrap.log`
  - This can be overridden by setting `log` to false when configuring Vedeu.
  - Also overridden by providing an alternative filename to `log`.
  - Remove now redundant `Vedeu::Config.log` method.
  - Disable logging when running tests for slight speed up. (Some output
    is still written to `/tmp/vedeu_bootstrap.log` but this is minimal.)

 Also minor improvements and additional documentation.