### PR TITLE
fix up delegated methods in distributed server, patch compatibility fix for Ruby 2.4

### DIFF
--- a/lib/vedeu/distributed/server.rb
+++ b/lib/vedeu/distributed/server.rb
@@ -244,19 +244,29 @@ module Vedeu
   # @api public
   # @!method drb_restart
   #   @see Vedeu::Distributed::Server#restart
+  def drb_restart
+    Vedeu::Distributed::Server.restart
+  end
+
   # @api public
   # @!method drb_start
   #   @see Vedeu::Distributed::Server#start
+  def drb_start
+    Vedeu::Distributed::Server.start
+  end
+
   # @api public
   # @!method drb_status
   #   @see Vedeu::Distributed::Server#status
+  def drb_status
+    Vedeu::Distributed::Server.status
+  end
+
   # @api public
   # @!method drb_stop
   #   @see Vedeu::Distributed::Server#stop
-  def_delegators Vedeu::Distributed::Server,
-                 :drb_restart,
-                 :drb_start,
-                 :drb_status,
-                 :drb_stop
+  def drb_stop
+    Vedeu::Distributed::Server.stop
+  end
 
 end # Vedeu

--- a/lib/vedeu/version.rb
+++ b/lib/vedeu/version.rb
@@ -3,6 +3,6 @@
 module Vedeu
 
   # The current version of Vedeu.
-  VERSION = '0.8.32'
+  VERSION = '0.8.33'
 
 end # Vedeu


### PR DESCRIPTION
This fixes an issue with the delegator methods in Ruby 2.4. Changes to Ruby introduced a compile which blows up delegated methods that eval:

`iseq = RubyVM::InstructionSequence.compile("().#{method}", nil, nil, 0, false)`

Change introduced here:

https://github.com/ruby/ruby/commit/2283d14cc9fefa278dfde02bdf8d84ce50cfe16f#diff-f8ad465135e9b25d06e71454b6e18317R6